### PR TITLE
Fix problem with url field encoding

### DIFF
--- a/resource/translators/BibTex.js.template
+++ b/resource/translators/BibTex.js.template
@@ -710,7 +710,7 @@ function doImport() {
 }
 
 function escape_url(str) {
-  return str.replace(/[\{\}\\_]/g, function(chr){'%' + ('00' + chr.charCodeAt(0).toString(16)).slice(-2)});
+  return str.replace(/[\{\}\\_]/g, function(chr){return '%' + ('00' + chr.charCodeAt(0).toString(16)).slice(-2)});
 }
 function escape(value, sep) {
   if (typeof value == 'number') { return value; }


### PR DESCRIPTION
escape_url caused http://en.wikipedia.org/wiki/Web_application to be escaped as http://en.wikipedia.org/wiki/Webundefinedapplication, caused
by a missing "return" statement. Fixed.
