### PR TITLE
Removed trailing comma from entries.

### DIFF
--- a/resource/translators/BetterBibLaTex.js.template
+++ b/resource/translators/BetterBibLaTex.js.template
@@ -112,7 +112,7 @@ function doExport() {
     var citekey = CiteKeys.build(item);
 
     // write citation key (removed the comma)
-    Zotero.write((first ? "" : ",\n\n") + "@"+type+"{"+citekey);
+    Zotero.write((first ? "" : "\n\n") + "@"+type+"{"+citekey);
     first = false;
 
     for(var field in fieldMap) {


### PR DESCRIPTION
The trailing comma resulted in warnings when running biber on the created files.
