### PR TITLE
_veryshorttitle should return 1 word instead of 3

### DIFF
--- a/resource/translators/BibTex.js.template
+++ b/resource/translators/BibTex.js.template
@@ -975,7 +975,7 @@ var CiteKeys = {
         return word.replace(/[^a-zA-Z]/, '');
       }).filter(function(word) {
         return (word != '' && CiteKeys.skipWords.indexOf(word.toLowerCase()) == -1);
-      }).slice(0,3).join('');
+      }).slice(0,1).join('');
   },
 
   _shortyear: function(item) {


### PR DESCRIPTION
Bugfix: According to JabRef, veryshorttitle should return a single word rather than three
