### PR TITLE
Minor language fix in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Install by downloading the [latest version](https://raw.github.com/friflaj/zoter
 
 1. In the main menu go to Tools → Add-ons
 2. Select ‘Extensions’
-3. Click on gear in the top-right corner and choose ‘Install Add-on From File...’
+3. Click on a gear in the top-right corner and choose ‘Install Add-on From File...’
 4. Choose .xpi that you’ve just downloaded, click ‘Install’
 5. Restart Zotero
 


### PR DESCRIPTION
Missed ‘a’ before ‘gear’ – sorry
