### PR TITLE
Capitalization of latin letters preserved.

### DIFF
--- a/resource/translators/unicodeconverter.js.template
+++ b/resource/translators/unicodeconverter.js.template
@@ -1,6 +1,106 @@
 
     var convert = {
       unicode2latex: {
+   "A": {
+    "latex": "\{A\}",
+    "force": true
+  },
+   "B": {
+    "latex": "\{B\}",
+    "force": true
+  },
+   "C": {
+    "latex": "\{C\}",
+    "force": true
+  },
+    "D": {
+    "latex": "\{D\}",
+    "force": true
+  },
+   "E": {
+    "latex": "\{E\}",
+    "force": true
+  },
+   "F": {
+    "latex": "\{F\}",
+    "force": true
+  },
+   "G": {
+    "latex": "\{G\}",
+    "force": true
+  },
+   "H": {
+    "latex": "\{H\}",
+    "force": true
+  },
+   "I": {
+    "latex": "\{I\}",
+    "force": true
+  },
+   "J": {
+    "latex": "\{J\}",
+    "force": true
+  },
+   "K": {
+    "latex": "\{K\}",
+    "force": true
+  },
+   "L": {
+    "latex": "\{L\}",
+    "force": true
+  },
+   "M": {
+    "latex": "\{M\}",
+    "force": true
+  },
+   "N": {
+    "latex": "\{N\}",
+    "force": true
+  },
+   "O": {
+    "latex": "\{O\}",
+    "force": true
+  },
+   "P": {
+    "latex": "\{P\}",
+    "force": true
+  },
+   "Q": {
+    "latex": "\{Q\}",
+    "force": true
+  },
+   "R": {
+    "latex": "\{R\}",
+    "force": true
+  },
+   "S": {
+    "latex": "\{S\}",
+    "force": true
+  },
+   "T": {
+    "latex": "\{T\}",
+    "force": true
+  },
+   "U": {
+    "latex": "\{U\}",
+    "force": true
+  },
+   "V": {
+    "latex": "\{V\}",
+    "force": true
+  },
+   "X": {
+    "latex": "\{X\}",
+    "force": true
+  },
+   "Y": {
+    "latex": "\{Y\}",
+    "force": true
+  },
+   "Z": {
+    "latex": "\{Z\}",
+    "force": true
+  },
   "#": {
     "latex": "\\#",
     "force": true


### PR DESCRIPTION
Hi, please take a look at proposed changes that may help preserve capitalization during export.
Please bear in mind that I am very new to JS and whatever language this is. I don't even know how to compile or interpret it :). But I'm just reproducing and sharing changes I made to the Better BibTeX translator in Forefox and it worked.
