### PR TITLE
Permit HTTP export of group libraries

### DIFF
--- a/chrome/content/zotero-better-bibtex/preferences.js
+++ b/chrome/content/zotero-better-bibtex/preferences.js
@@ -12,7 +12,7 @@ function serverURL(collectionsView, extension)
   }
 
   var isLibrary = true;
-  for (var type of ['Collection', 'Search', 'Trash', 'Group', 'Duplicates', 'Unfiled', 'Header', 'Bucket']) {
+  for (var type of ['Collection', 'Search', 'Trash', 'Duplicates', 'Unfiled', 'Header', 'Bucket']) {
     if (itemGroup['is' + type]()) {
       isLibrary = false;
       break;
@@ -27,7 +27,12 @@ function serverURL(collectionsView, extension)
   }
 
   if (isLibrary) {
-    url = 'library?library' + extension;
+    var libid = collectionsView.getSelectedLibraryID();
+    if (libid) {
+        url = 'library?/' + libid + '/library' + extension;
+    } else {
+        url = 'library?library' + extension;
+    }
   }
 
   if (!url) { return; }

--- a/chrome/content/zotero-better-bibtex/zotero-better-bibtex.js
+++ b/chrome/content/zotero-better-bibtex/zotero-better-bibtex.js
@@ -204,7 +204,20 @@ Zotero.BetterBibTex = {
         }
 
         try {
-          var path = library.split('.');
+          var libid = 0;
+          var path = library.split('/');
+          if (path.length > 1) {
+              path.shift(); // leading /
+              libid = parseInt(path[0]);
+              path.shift();
+
+              if (!Zotero.Libraries.exists(libid)) {
+                  sendResponseCallback(404, "text/plain", "Could not export bibliography: library '" + library + "' does not exist");
+                  return;
+              }
+          }
+
+          var path = path.join('/').split('.');
 
           if (path.length == 1) {
             sendResponseCallback(404, "text/plain", "Could not export bibliography '" + library + "': no format specified");
@@ -217,13 +230,13 @@ Zotero.BetterBibTex = {
             "text/plain",
             Zotero.BetterBibTex.translate(
               Zotero.BetterBibTex.getTranslator(translator),
-              Zotero.Items.getAll(),
+              Zotero.Items.getAll(false, libid, false),
               Zotero.BetterBibTex.displayOptions(url)
             )
           );
         } catch (err) {
-          Zotero.BetterBibTex.log("Could not export bibliography '" + collection + "'", err);
-          sendResponseCallback(404, "text/plain", "Could not export bibliography '" + collection + "': " + err);
+          Zotero.BetterBibTex.log("Could not export bibliography '" + library + "'", err);
+          sendResponseCallback(404, "text/plain", "Could not export bibliography '" + library + "': " + err);
         }
       }
     }


### PR DESCRIPTION
Current master fails with 'HTTP export disabled' error when you try and get the export URL.
