### PR TITLE
correct grammar, based on spoken sound

### DIFF
--- a/content/Preferences.xul
+++ b/content/Preferences.xul
@@ -166,7 +166,7 @@
         <!--!
           BibLaTeX supports urls in your references natively; BibTeX does not. For this reason, URLs are
           omitted from BibTeX exports by default. Using this setting you can have them added to your exports either in a `note`
-          field (not as clean, but compatible with BibTeX out of the box), or in an `url` field (requires extra packages to be loaded,
+          field (not as clean, but compatible with BibTeX out of the box), or in a `url` field (requires extra packages to be loaded,
           or bibtex will error out).
         -->
 

--- a/locale/en-US/zotero-better-bibtex.dtd
+++ b/locale/en-US/zotero-better-bibtex.dtd
@@ -63,13 +63,13 @@ https://github.com/retorquere/zotero-better-bibtex/issue">
 <!ENTITY better-bibtex.Preferences.export.bibtex.URLs "Add URLs to BibTeX export">
 <!ENTITY better-bibtex.Preferences.export.bibtex.URLs.note "in a note field">
 <!ENTITY better-bibtex.Preferences.export.bibtex.URLs.off "no">
-<!ENTITY better-bibtex.Preferences.export.bibtex.URLs.url "in an url field">
+<!ENTITY better-bibtex.Preferences.export.bibtex.URLs.url "in a url field">
 <!ENTITY better-bibtex.Preferences.tab.export "Export">
 <!ENTITY better-bibtex.Preferences.export.fields.bibtexParticleNoOp "Disregard name prefixes when sorting">
 <!ENTITY better-bibtex.Preferences.export.fields.doi-and-url.both "both">
 <!ENTITY better-bibtex.Preferences.export.fields.doi-and-url.DOI "DOI">
 <!ENTITY better-bibtex.Preferences.export.fields.doi-and-url.URL "URL">
-<!ENTITY better-bibtex.Preferences.export.fields.doi-and-url "When a reference has both a DOI and an URL, export">
+<!ENTITY better-bibtex.Preferences.export.fields.doi-and-url "When a reference has both a DOI and a URL, export">
 <!ENTITY better-bibtex.Preferences.export.fields "Fields">
 <!ENTITY better-bibtex.Preferences.export.fields.preserveBibTeXVariables "Assume single-word strings to be externally-defined @string vars, and thus not surrounded by braces">
 <!ENTITY better-bibtex.Preferences.export.fields.skip "Fields to omit from export (comma-separated)">


### PR DESCRIPTION
Hello, and my apologies up-front for nit-picking here ;-)

Because the `U` in `URL` stands in for [uniform](https://en.wiktionary.org/wiki/uniform#English), and that is spoken with a `j`-like consonant sound, the common rule "an before vowels" doesn't match here. Many English words starting with `u` are exceptions here. A true example would be "an [Up Goer Five](https://xkcd.com/1133/)" ;-D

Nonetheless: 1k thanks for this neat add-on!