### PR TITLE
Move journal abbreviations to Export tab

### DIFF
--- a/content/Preferences.ts
+++ b/content/Preferences.ts
@@ -257,9 +257,9 @@ export = new class PrefPane {
     }, 500) // tslint:disable-line:no-magic-numbers
 
     // document.getElementById('better-bibtex-prefs-tab-journal-abbrev').setAttribute('hidden', !ZoteroConfig.Zotero.isJurisM)
-    document.getElementById('better-bibtex-abbrev-style').setAttribute('hidden', !ZoteroConfig.Zotero.isJurisM)
-    document.getElementById('better-bibtex-abbrev-style-label').setAttribute('hidden', !ZoteroConfig.Zotero.isJurisM)
-    document.getElementById('better-bibtex-abbrev-style-separator').setAttribute('hidden', !ZoteroConfig.Zotero.isJurisM)
+    document.getElementById('better-bibtex-abbrev-style').setAttribute('collapsed', !ZoteroConfig.Zotero.isJurisM)
+    document.getElementById('better-bibtex-abbrev-style-label').setAttribute('collapsed', !ZoteroConfig.Zotero.isJurisM)
+    document.getElementById('better-bibtex-abbrev-style-separator').setAttribute('collapsed', !ZoteroConfig.Zotero.isJurisM)
 
     $patch$(Zotero_Preferences, 'openHelpLink', original => function() {
       if (document.getElementsByTagName('prefwindow')[0].currentPane.helpTopic === 'BetterBibTeX') {

--- a/content/Preferences.ts
+++ b/content/Preferences.ts
@@ -335,13 +335,13 @@ export = new class PrefPane {
         const styles = Zotero.Styles.getVisible().filter(style => style.usesAbbreviation)
         debug('prefPane.update: found styles', styles)
 
-        const stylebox = document.getElementById('better-bibtex-abbrev-style')
+        const stylebox = document.getElementById('better-bibtex-abbrev-style-popup')
         const refill = stylebox.children.length === 0
         const selectedStyle = Prefs.get('autoAbbrevStyle')
         let selectedIndex = -1
         for (const [i, style] of styles.entries()) {
           if (refill) {
-            const itemNode = document.createElement('listitem')
+            const itemNode = document.createElement('menuitem')
             itemNode.setAttribute('value', style.styleID)
             itemNode.setAttribute('label', style.title)
             stylebox.appendChild(itemNode)
@@ -369,7 +369,7 @@ export = new class PrefPane {
   private styleChanged(index) {
     if (!ZoteroConfig.Zotero.isJurisM) return
 
-    const stylebox = document.getElementById('better-bibtex-abbrev-style')
+    const stylebox = document.getElementById('better-bibtex-abbrev-style-popup')
     const selectedItem = typeof index !== 'undefined' ? stylebox.getItemAtIndex(index) : stylebox.selectedItem
     const styleID = selectedItem.getAttribute('value')
     Prefs.set('autoAbbrevStyle', styleID)

--- a/content/Preferences.ts
+++ b/content/Preferences.ts
@@ -259,6 +259,7 @@ export = new class PrefPane {
     // document.getElementById('better-bibtex-prefs-tab-journal-abbrev').setAttribute('hidden', !ZoteroConfig.Zotero.isJurisM)
     document.getElementById('better-bibtex-abbrev-style').setAttribute('hidden', !ZoteroConfig.Zotero.isJurisM)
     document.getElementById('better-bibtex-abbrev-style-label').setAttribute('hidden', !ZoteroConfig.Zotero.isJurisM)
+    document.getElementById('better-bibtex-abbrev-style-separator').setAttribute('hidden', !ZoteroConfig.Zotero.isJurisM)
 
     $patch$(Zotero_Preferences, 'openHelpLink', original => function() {
       if (document.getElementsByTagName('prefwindow')[0].currentPane.helpTopic === 'BetterBibTeX') {

--- a/content/Preferences.xul
+++ b/content/Preferences.xul
@@ -547,13 +547,17 @@
             <groupbox>
               <caption label="&better-bibtex.Preferences.export.journal-abbrev;"/>
               <checkbox id="id-better-bibtex-preferences-autoAbbrev" label="&better-bibtex.Preferences.auto-abbrev;" preference="pref-better-bibtex-autoAbbrev"/>
+              <separator id="better-bibtex-abbrev-style-separator" class="thin"/>
               <label id="better-bibtex-abbrev-style-label" forpreference="pref-better-bibtex-autoAbbrev">&better-bibtex.Preferences.auto-abbrev.style;</label>
-              <listbox id="better-bibtex-abbrev-style" onselect="Zotero.BetterBibTeX.Preferences.styleChanged()"/>
+              <listbox id="better-bibtex-abbrev-style" rows="5" onselect="Zotero.BetterBibTeX.Preferences.styleChanged()"/>
             </groupbox>
+
+          </tabpanel>
 
           <tabpanel id="better-bibtex-prefs-journal-automatic-export" orient="vertical">
             <vbox flex="1">
               <label>&better-bibtex.Preferences.auto-export.add;</label>
+              <separator class="thin"/>
               <hbox>
                 <label forpreference="pref-better-bibtex-autoExport">&better-bibtex.Preferences.auto-export;</label>
                 <menulist preference="pref-better-bibtex-autoExport">
@@ -565,7 +569,7 @@
                 </menulist>
               </hbox>
               <hbox>
-                <tree id="better-bibtex-export-list" flex="1" seltype="single" height="200" editable="false" ondblclick="Zotero.BetterBibTeX.Preferences.aeToggle(event)">
+                <tree id="better-bibtex-export-list" flex="1" seltype="single" hidecolumnpicker="true" height="200" editable="false" ondblclick="Zotero.BetterBibTeX.Preferences.aeToggle(event)">
                   <treecols>
                     <treecol id="better-bibtex-export-list-name" label="&better-bibtex.Preferences.auto-export.status;" editable="false" flex="1" persist="width ordinal hidden" primary="true"/>
                     <splitter class="tree-splitter"/>

--- a/content/Preferences.xul
+++ b/content/Preferences.xul
@@ -395,7 +395,6 @@
         <tabs id="better-bibtex-prefs-tabs" onselect="window.sizeToContent()">
           <tab label="&better-bibtex.Preferences.tab.citekey;"/>
           <tab label="&better-bibtex.Preferences.tab.export;"/>
-          <tab id="better-bibtex-prefs-tab-journal-abbrev" label="&better-bibtex.Preferences.tab.journal-abbrev;"/>
           <tab id="better-bibtex-prefs-auto-export" label="&better-bibtex.Preferences.tab.auto-export;"/>
           <tab label="&better-bibtex.Preferences.debug;"/>
         </tabs>
@@ -545,15 +544,12 @@
               <checkbox label="&better-bibtex.Preferences.export.qualityReport;" preference="pref-better-bibtex-qualityReport"/>
             </groupbox>
 
-          </tabpanel>
-
-          <tabpanel id="better-bibtex-prefs-journal-abbreviations" orient="vertical">
-            <vbox>
-              <label id="better-bibtex-abbrev-style-label" forpreference="pref-better-bibtex-autoAbbrev">&better-bibtex.Preferences.auto-abbrev.style;</label>
+            <groupbox>
+              <caption label="&better-bibtex.Preferences.export.journal-abbrev;"/>
               <checkbox id="id-better-bibtex-preferences-autoAbbrev" label="&better-bibtex.Preferences.auto-abbrev;" preference="pref-better-bibtex-autoAbbrev"/>
+              <label id="better-bibtex-abbrev-style-label" forpreference="pref-better-bibtex-autoAbbrev">&better-bibtex.Preferences.auto-abbrev.style;</label>
               <listbox id="better-bibtex-abbrev-style" onselect="Zotero.BetterBibTeX.Preferences.styleChanged()"/>
-            </vbox>
-          </tabpanel>
+            </groupbox>
 
           <tabpanel id="better-bibtex-prefs-journal-automatic-export" orient="vertical">
             <vbox flex="1">

--- a/content/Preferences.xul
+++ b/content/Preferences.xul
@@ -549,7 +549,10 @@
               <checkbox id="id-better-bibtex-preferences-autoAbbrev" label="&better-bibtex.Preferences.auto-abbrev;" preference="pref-better-bibtex-autoAbbrev"/>
               <separator id="better-bibtex-abbrev-style-separator" class="thin"/>
               <label id="better-bibtex-abbrev-style-label" forpreference="pref-better-bibtex-autoAbbrev">&better-bibtex.Preferences.auto-abbrev.style;</label>
-              <listbox id="better-bibtex-abbrev-style" rows="5" onselect="Zotero.BetterBibTeX.Preferences.styleChanged()"/>
+              <menulist id="better-bibtex-abbrev-style" onchange="Zotero.BetterBibTeX.Preferences.styleChanged()">
+                <menupopup id="better-bibtex-abbrev-style-popup">
+                </menupopup>
+              </menulist>
             </groupbox>
 
           </tabpanel>

--- a/content/Preferences.xul
+++ b/content/Preferences.xul
@@ -598,13 +598,13 @@
               </tabs>
               <tabpanels>
                 <tabpanel orient="vertical">
-                  <textbox rows="20" flex="1" multiline="true" preference="pref-better-bibtex-postscript" id="zotero-better-bibtex-postscript"
+                  <textbox rows="10" flex="1" multiline="true" preference="pref-better-bibtex-postscript" id="zotero-better-bibtex-postscript"
                         onblur="Zotero.BetterBibTeX.Preferences.checkPostscript();"
                         oninput="Zotero.BetterBibTeX.Preferences.checkPostscript();"
                         onkeypress="setTimeout(function() { Zotero.BetterBibTeX.Preferences.checkPostscript() }, 1);"/>
                 </tabpanel>
                 <tabpanel orient="vertical">
-                  <textbox rows="20" flex="1" multiline="true" preference="pref-better-bibtex-strings"/>
+                  <textbox rows="10" flex="1" multiline="true" preference="pref-better-bibtex-strings"/>
                 </tabpanel>
               </tabpanels>
             </tabbox>

--- a/locale/en-US/zotero-better-bibtex.dtd
+++ b/locale/en-US/zotero-better-bibtex.dtd
@@ -100,7 +100,7 @@ https://github.com/retorquere/zotero-better-bibtex/issue">
 <!ENTITY better-bibtex.Preferences.export.fields "Fields">
 <!ENTITY better-bibtex.Preferences.export.fields.preserveBibTeXVariables "Assume single-word strings to be externally-defined @string vars, and thus not surrounded by braces">
 <!ENTITY better-bibtex.Preferences.export.fields.skip "Fields to omit from export (comma-separated)">
-<!ENTITY better-bibtex.Preferences.tab.journal-abbrev "Journal abbreviations">
+<!ENTITY better-bibtex.Preferences.export.journal-abbrev "Journal abbreviations">
 <!ENTITY better-bibtex.Preferences.tab.postscript "postscript">
 <!ENTITY better-bibtex.Preferences.tab.strings "import @string definitions">
 <!ENTITY better-bibtex.Preferences.prefpane.better-bibtex "Better BibTeX">


### PR DESCRIPTION
It conceptually fits there well. I tried having a separator between the checkbox and the "Abbreviation style:" label and listbox, but thought that this looked better.