### PR TITLE
Do not use more than three initials in case of authshort key

### DIFF
--- a/content/key-manager/formatter.ts
+++ b/content/key-manager/formatter.ts
@@ -337,7 +337,7 @@ class PatternFormatter {
 
       default:
         // tslint:disable-next-line:no-magic-numbers
-        return authors.map(author => author.substring(0, 1)).join('.') + (authors.length > 3 ? '+' : '')
+        return authors.slice(0, 3).map(author => author.substring(0, 1)).join('.') + (authors.length > 3 ? '+' : '')
     }
   }
 


### PR DESCRIPTION
According to the documentation, the `authshort` key is supposed to give

> The last name if one author is given; the first character **of up to three authors’ last names** if more than one author is given. A plus character is added, if there are more than three authors.

This is also reflected in the comment in line 326 of the modified file. However, the current implementation gives first characters for all authors, and then adds a plus if there were more than three of them.

To reproduce this bug: My configuration is `[authshort:nopunct][shortyear]`; a paper by authors Alpha, Beta, Gamma, Delta receives the key `ABGD+18`, whereas the expected behavior would be `ABG+18`.

Based on the surrounding code, I expect this pull request to fix the bug. However, I failed at building the plugin, and therefore was unable to check this. Could someone please test it before merging?