### PR TITLE
zotero.lua: Produce live / transferable docs with a custom style and bibliography

### DIFF
--- a/pandoc/Makefile
+++ b/pandoc/Makefile
@@ -29,6 +29,46 @@ paper:
 	#unzip paper$(TIMESTAMP)-scannable-cite.odt content.xml
 	#grep @wrigstad2017mastery content.xml
 
+%.md:
+	cp test.md $@
+
+odt-scannable-cite.odt:     ZOTERO_OPTIONS = --metadata=zotero_scannable_cite:true
+odt-scannable-cite.odt:     odt
+
+odt-with-csl-style.odt:     ZOTERO_CSL_STYLE = chicago-author-date
+odt-with-csl-style.odt:     ZOTERO_OPTIONS = --metadata=zotero_csl_style:$(ZOTERO_CSL_STYLE)
+odt-with-csl-style.odt:     odt
+
+odt-without-csl-style.odt : odt
+
+.PHONY: %.odt
+
+%.odt: %.md
+	rm -f *.docx $@.odt *.json *.xml
+	@echo ""
+	@echo "---------------- CONTENTS OF $< ----------------"
+	@cat  $<
+	@echo ""
+	@echo "---------------- AST FOR $< ----------------"
+	@echo ""
+	pandoc -s $(ZOTERO_OPTIONS) -L  $(BUNDLED) -t native  $<
+	@echo ""
+	@echo "---------------- Making $@ ----------------"
+	@echo ""
+	pandoc -s $(ZOTERO_OPTIONS) -L  $(BUNDLED) -o $@ $<
+	unzip $@ content.xml meta.xml
+	@echo ""
+	@echo "content.xml:"
+	@cat content.xml | tail
+	@echo ""
+	@echo "meta.xml:"
+	@cat meta.xml | tail
+
+test-odt: bundle test-clean odt-scannable-cite.odt odt-without-csl-style.odt odt-with-csl-style.odt
+
+test-clean:
+	rm -f *.docx *.odt *.json *.xml
+
 1528:
 	@rm -f *.docx *.odt *.json
 	@pandoc -s --lua-filter=$(MAIN) -o 1528-$(TIMESTAMP).docx gh-1528.md

--- a/pandoc/pandoc-zotero-live-citemarkers.lua
+++ b/pandoc/pandoc-zotero-live-citemarkers.lua
@@ -31,8 +31,25 @@ local zotero = require('zotero')
 -- -- global state -- --
 local config = {
   client = 'zotero',
-  scannable_cite = false
+  scannable_cite = false,
+  csl_style=''
 }
+
+-- -- -- bibliography marker generator -- -- --
+local function zotero_bibl()
+  if (not string.match(FORMAT, 'odt')) or config.csl_style == '' then return '' end
+
+  local message = '<Bibliography: Do Zotero Refresh>'
+  local docprefs = '{"uncited":[],"omitted":[],"custom":[]}'
+
+  return string.format(
+    '<text:section text:name=" %s">'
+      .. '<text:p text:style-name="Bibliography_20_1">'
+      .. utils.xmlescape(message)
+      .. '</text:p>'
+      ..'</text:section>',
+    'ZOTERO_BIBL ' .. utils.xmlescape(docprefs) .. ' CSL_BIBLIOGRAPHY' .. ' RND' .. utils.random_id(10))
+end
 
 -- -- -- citation market generators -- -- --
 local function zotero_ref(cite)
@@ -41,7 +58,9 @@ local function zotero_ref(cite)
     citationID = utils.random_id(8),
     properties = {
       formattedCitation = content,
-      plainCitation = content,
+      plainCitation = nil,
+      -- plainCitation = content,
+      -- dontUpdate = false,
       noteIndex = 0
     },
     citationItems = {},
@@ -93,9 +112,10 @@ local function zotero_ref(cite)
 
     return pandoc.RawInline('openxml', field)
   else
+    local message = '<Do Zotero Refresh: ' .. content .. '>'
     csl = 'ZOTERO_ITEM CSL_CITATION ' .. utils.xmlescape(json.encode(csl)) .. ' RND' .. utils.random_id(10)
     local field = '<text:reference-mark-start text:name="' .. csl .. '"/>'
-    field = field .. utils.xmlescape('<open Zotero document preferences: ' .. utils.xmlescape(content) .. '>')
+    field = field .. utils.xmlescape(message)
     field = field .. '<text:reference-mark-end text:name="' .. csl .. '"/>'
 
     return pandoc.RawInline('opendocument', field)
@@ -194,6 +214,10 @@ function Meta(meta)
   config.scannable_cite = test_boolean('scannable-cite', meta.zotero['scannable-cite'])
   config.author_in_text = test_boolean('author-in-text', meta.zotero['author-in-text'])
 
+  if meta.zotero['csl-style'] ~= nil then
+    config.csl_style = pandoc.utils.stringify(meta.zotero['csl-style'])
+  end
+
   if type(meta.zotero.client) == 'nil' then
     meta.zotero.client = 'zotero'
   else
@@ -221,6 +245,29 @@ function Meta(meta)
   end
 
   zotero.url = zotero.url .. '&citationKeys='
+
+  if string.match(FORMAT, 'odt') and config.csl_style ~= '' then
+    meta.ZOTERO_PREF_1 = string.format(
+      '<data data-version="3" zotero-version="5.0.89">'
+        .. '   <session id="OGe1IYVe"/>'
+        .. '   <style id="http://www.zotero.org/styles/%s" locale="en-US" hasBibliography="1" bibliographyStyleHasBeenSet="0"/>'
+        .. '   <prefs>'
+        .. '     <pref name="fieldType" value="ReferenceMark"/>'
+      -- .. '     <pref name="delayCitationUpdates" value="true"/>'
+        .. '   </prefs>'
+        .. '</data>',
+      config.csl_style)
+    meta.ZOTERO_PREF_2 = ''
+  end
+
+  print('')
+  print('config')
+  print(' scannable_cite          => ' .. tostring(config.scannable_cite))
+  print(' FORMAT                  => ' .. FORMAT)
+  print(' csl_style               => ' .. config.csl_style)
+  print('')
+
+  return meta
 end
 
 -- -- -- replace citations -- -- --
@@ -244,8 +291,27 @@ function Cite_replace(cite)
   end
 end
 
+local refsDivSeen=false
+function Div(div)
+  if not div.attr or div.attr.identifier ~= 'refs' then return nil end
+  refsDivSeen=true
+  if (not string.match(FORMAT, 'odt')) or config.csl_style == '' then return nil end
+  return pandoc.RawBlock('opendocument', zotero_bibl())
+
+end
+
+function Doc(doc)
+  if refsDivSeen then return nil end
+  if (not string.match(FORMAT, 'odt')) or config.csl_style == '' then return nil end
+
+  table.insert(doc.blocks, pandoc.RawBlock('opendocument', zotero_bibl()))
+  return pandoc.Pandoc(doc.blocks, doc.meta)
+end
+
 return {
   { Meta = Meta },
   { Cite = Cite_collect },
   { Cite = Cite_replace },
+  { Div = Div },
+  { Doc = Doc },
 }

--- a/pandoc/test.md
+++ b/pandoc/test.md
@@ -1,0 +1,5 @@
+::: {#refs}
+:::
+
+[@wrigstad2017mastery]
+

--- a/site/content/exporting/zotero.lua
+++ b/site/content/exporting/zotero.lua
@@ -1829,8 +1829,25 @@ local zotero = require('zotero')
 -- -- global state -- --
 local config = {
   client = 'zotero',
-  scannable_cite = false
+  scannable_cite = false,
+  csl_style=''
 }
+
+-- -- -- bibliography marker generator -- -- --
+local function zotero_bibl()
+  if (not string.match(FORMAT, 'odt')) or config.csl_style == '' then return '' end
+
+  local message = '<Bibliography: Do Zotero Refresh>'
+  local docprefs = '{"uncited":[],"omitted":[],"custom":[]}'
+
+  return string.format(
+    '<text:section text:name=" %s">'
+      .. '<text:p text:style-name="Bibliography_20_1">'
+      .. utils.xmlescape(message)
+      .. '</text:p>'
+      ..'</text:section>',
+    'ZOTERO_BIBL ' .. utils.xmlescape(docprefs) .. ' CSL_BIBLIOGRAPHY' .. ' RND' .. utils.random_id(10))
+end
 
 -- -- -- citation market generators -- -- --
 local function zotero_ref(cite)
@@ -1839,7 +1856,9 @@ local function zotero_ref(cite)
     citationID = utils.random_id(8),
     properties = {
       formattedCitation = content,
-      plainCitation = content,
+      plainCitation = nil,
+      -- plainCitation = content,
+      -- dontUpdate = false,
       noteIndex = 0
     },
     citationItems = {},
@@ -1891,9 +1910,10 @@ local function zotero_ref(cite)
 
     return pandoc.RawInline('openxml', field)
   else
+    local message = '<Do Zotero Refresh: ' .. content .. '>'
     csl = 'ZOTERO_ITEM CSL_CITATION ' .. utils.xmlescape(json.encode(csl)) .. ' RND' .. utils.random_id(10)
     local field = '<text:reference-mark-start text:name="' .. csl .. '"/>'
-    field = field .. utils.xmlescape('<open Zotero document preferences: ' .. utils.xmlescape(content) .. '>')
+    field = field .. utils.xmlescape(message)
     field = field .. '<text:reference-mark-end text:name="' .. csl .. '"/>'
 
     return pandoc.RawInline('opendocument', field)
@@ -1992,6 +2012,10 @@ function Meta(meta)
   config.scannable_cite = test_boolean('scannable-cite', meta.zotero['scannable-cite'])
   config.author_in_text = test_boolean('author-in-text', meta.zotero['author-in-text'])
 
+  if meta.zotero['csl-style'] ~= nil then
+    config.csl_style = pandoc.utils.stringify(meta.zotero['csl-style'])
+  end
+
   if type(meta.zotero.client) == 'nil' then
     meta.zotero.client = 'zotero'
   else
@@ -2019,6 +2043,29 @@ function Meta(meta)
   end
 
   zotero.url = zotero.url .. '&citationKeys='
+
+  if string.match(FORMAT, 'odt') and config.csl_style ~= '' then
+    meta.ZOTERO_PREF_1 = string.format(
+      '<data data-version="3" zotero-version="5.0.89">'
+        .. '   <session id="OGe1IYVe"/>'
+        .. '   <style id="http://www.zotero.org/styles/%s" locale="en-US" hasBibliography="1" bibliographyStyleHasBeenSet="0"/>'
+        .. '   <prefs>'
+        .. '     <pref name="fieldType" value="ReferenceMark"/>'
+      -- .. '     <pref name="delayCitationUpdates" value="true"/>'
+        .. '   </prefs>'
+        .. '</data>',
+      config.csl_style)
+    meta.ZOTERO_PREF_2 = ''
+  end
+
+  print('')
+  print('config')
+  print(' scannable_cite          => ' .. tostring(config.scannable_cite))
+  print(' FORMAT                  => ' .. FORMAT)
+  print(' csl_style               => ' .. config.csl_style)
+  print('')
+
+  return meta
 end
 
 -- -- -- replace citations -- -- --
@@ -2042,8 +2089,27 @@ function Cite_replace(cite)
   end
 end
 
+local refsDivSeen=false
+function Div(div)
+  if not div.attr or div.attr.identifier ~= 'refs' then return nil end
+  refsDivSeen=true
+  if (not string.match(FORMAT, 'odt')) or config.csl_style == '' then return nil end
+  return pandoc.RawBlock('opendocument', zotero_bibl())
+
+end
+
+function Doc(doc)
+  if refsDivSeen then return nil end
+  if (not string.match(FORMAT, 'odt')) or config.csl_style == '' then return nil end
+
+  table.insert(doc.blocks, pandoc.RawBlock('opendocument', zotero_bibl()))
+  return pandoc.Pandoc(doc.blocks, doc.meta)
+end
+
 return {
   { Meta = Meta },
   { Cite = Cite_collect },
   { Cite = Cite_replace },
+  { Div = Div },
+  { Doc = Doc },
 }


### PR DESCRIPTION
See demo at [https://gitlab.com/kjambunathan/scratch/-/issues/3](https://gitlab.com/kjambunathan/scratch/-/issues/3)

With this  enhancement one

1. _need not_ configure a csl style
2. _need not_  add a bibliography
3.  can create transferable documents.

Start with video in the attached zip file.  Alternately, you can see the video online here: https://gitlab.com/kjambunathan/scratch/-/issues/3

The commit message in the  attached zip file reads:

    Add support for dummy bibliographies.  Add ability to produce a
    transferable document. [Moving Documents with Zotero Citations
    Between Word
    Processors](https://www.zotero.org/support/kb/moving_documents_between_word_processors).
    
    Here is a sample command line to produce a tranferable document:
    
    pandoc -s --metadata=zotero_scannable_cite:false        \
    --metadata=zotero_csl_style:chicago-author-date \
    --metadata=zotero_transferable:true             \
    -L  zotero.lua -o transferable.odt ww.md
    
    To test drive this feature, run
    
            make bundle; make scannable-cite; make regular; make transferable;
    
    This will produce three documents (1) scannable-cite.odt (2)
    regular.odt and (3) transferable.odt
    Add support for dummy bibliographies.  Add ability to produce a
    transferable document. [Moving Documents with Zotero Citations
    Between Word
    Processors](https://www.zotero.org/support/kb/moving_documents_between_word_processors).
    
    Here is a sample command line to produce a tranferable document:
    
    pandoc -s --metadata=zotero_scannable_cite:false        \
    --metadata=zotero_csl_style:chicago-author-date \
    --metadata=zotero_transferable:true             \
    -L  zotero.lua -o transferable.odt ww.md
    
    To test drive this feature, run
    
            make bundle; make scannable-cite; make regular; make transferable;
    
    This will produce three documents (1) scannable-cite.odt (2)
    regular.odt and (3) transferable.odt






[zotero-PR.zip](https://github.com/retorquere/zotero-better-bibtex/files/4977632/zotero-PR.zip)





