### PR TITLE
zotero.lua:  Produce live ODT documents with Biblography (of specific…

### DIFF
--- a/pandoc/Makefile
+++ b/pandoc/Makefile
@@ -29,6 +29,42 @@ paper:
 	#unzip paper$(TIMESTAMP)-scannable-cite.odt content.xml
 	#grep @wrigstad2017mastery content.xml
 
+%.md:
+	cp test.md $@
+
+odt-scannable-cite.odt:     ZOTERO_OPTIONS = --metadata=zotero_scannable_cite:true
+
+odt-with-csl-style.odt:     ZOTERO_CSL_STYLE = chicago-author-date
+odt-with-csl-style.odt:     ZOTERO_OPTIONS = --metadata=zotero_csl_style:$(ZOTERO_CSL_STYLE)
+
+odt-without-csl-style.odt:
+
+%.odt: %.md
+	rm -f *.docx $@.odt *.json *.xml
+	@echo ""
+	@echo "---------------- CONTENTS OF $< ----------------"
+	@cat  $<
+	@echo ""
+	@echo "---------------- AST FOR $< ----------------"
+	@echo ""
+	pandoc -s $(ZOTERO_OPTIONS) -L  $(BUNDLED) -t native  $<
+	@echo ""
+	@echo "---------------- Making $@ ----------------"
+	@echo ""
+	pandoc -s $(ZOTERO_OPTIONS) -L  $(BUNDLED) -o $@ $<
+	unzip $@ content.xml meta.xml
+	@echo ""
+	@echo "content.xml:"
+	@cat content.xml | tail
+	@echo ""
+	@echo "meta.xml:"
+	@cat meta.xml | tail
+
+test-odt: bundle test-clean odt-scannable-cite.odt odt-without-csl-style.odt odt-with-csl-style.odt
+
+test-clean:
+	rm -f *.docx *.odt *.json *.xml
+
 1528:
 	@rm -f *.docx *.odt *.json
 	@pandoc -s --lua-filter=$(MAIN) -o 1528-$(TIMESTAMP).docx gh-1528.md

--- a/pandoc/test.md
+++ b/pandoc/test.md
@@ -1,0 +1,5 @@
+::: {#refs}
+:::
+
+[@wrigstad2017mastery]
+


### PR DESCRIPTION
I am re-submitting the PR with squashed changes.  

Hope this one sails through.  Feel free to adopt the changes to your taste--This  will be a lot easier on both of us.

… CSL style)

* pandoc/pandoc-zotero-live-citemarkers.lua (Meta): New metadata
option `zotero_csl_style'.  When a CSL style is specified, store
it in LibreOffice's user-variables `ZOTERO_PREF_1` and
`ZOTERO_PREF_2`.

(config):  New key `csl_style'.

(zotero_bibl): New.  Bibliography marker.

(zotero_ref): Set `properties.plainCitation' to nil.  This helps
in importing live documents with CSL styles with no GUI dialog
whatsoever.  See
https://github.com/zotero/zotero/blob/aebe2b78240033321d120f421790836c5c6a2e83/chrome/content/zotero/xpcom/integration.js#L1104

Change in-text message to `Do Zotero Refresh'.  This makes sense for
live documents of either types: those with CSL style and those without
one.

(refsDivseen): New global variable.

(Div):  Replace #refs Div with Bibliography.

(Doc): Append Bibliography to the document's body text (when there is
no #refs Di)

* pandoc/Makefile (odt-scannable-cite.odt, odt-with-csl-style.odt)
(odt-without-csl-style.odt, test-odt, test-clean, %.md, %.odt): New
targets and build rules to test drive above feature.

To run all the unit tests do

    make  test-odt

* pandoc/test.md: Input file for unit test.

To produce a live documents with no style preferences do,

        pandoc -s  -L  zotero.lua ...

To produce a live document with a CSL style do,

    pandoc -s --metadata=zotero_csl_style:chicago-author-date -L  zotero.lua  ...

Resolve change requests at https://github.com/retorquere/zotero-better-bibtex/pull/1592