### PR TITLE
zotero.lua: Add support for generating transferable live ODT document

### DIFF
--- a/pandoc/Makefile
+++ b/pandoc/Makefile
@@ -29,12 +29,16 @@ test:
 %.md:
 	cp test.md $@
 
-odt-scannable-cite.odt:     ZOTERO_OPTIONS = --metadata=zotero_scannable_cite:true
+ZOTERO_TRANSFERABLE = true
 
-odt-with-csl-style.odt:     ZOTERO_CSL_STYLE = chicago-author-date
-odt-with-csl-style.odt:     ZOTERO_OPTIONS = --metadata=zotero_csl_style:$(ZOTERO_CSL_STYLE)
+odt-scannable-cite.odt:    ZOTERO_OPTIONS = --metadata=zotero_scannable_cite:true \
+                                          --metadata=zotero_transferable:$(ZOTERO_TRANSFERABLE) # don't care
 
-odt-without-csl-style.odt:
+odt-with-csl-style.odt:    ZOTERO_CSL_STYLE = chicago-author-date
+odt-with-csl-style.odt:    ZOTERO_OPTIONS = --metadata=zotero_csl_style:$(ZOTERO_CSL_STYLE) \
+                                          --metadata=zotero_transferable:$(ZOTERO_TRANSFERABLE) 
+
+odt-without-csl-style.odt: ZOTERO_OPTIONS = --metadata=zotero_transferable:$(ZOTERO_TRANSFERABLE) # don't care
 
 %.odt: %.md
 	make clean

--- a/pandoc/pandoc-zotero-live-citemarkers.lua
+++ b/pandoc/pandoc-zotero-live-citemarkers.lua
@@ -34,16 +34,70 @@ local config = {
   scannable_cite = false,
   csl_style = nil, -- more to document than anything else -- Lua does not store nils in tables
   format = nil, -- more to document than anything else -- Lua does not store nils in tables
+  transferable = false
 }
 
 -- -- -- bibliography marker generator -- -- --
+function zotero_docpreferences_odt(csl_style)
+  return string.format(
+    '<data data-version="3" zotero-version="5.0.89">'
+      .. '   <session id="OGe1IYVe"/>'
+      .. '   <style id="http://www.zotero.org/styles/%s" locale="en-US" hasBibliography="1" bibliographyStyleHasBeenSet="0"/>'
+      .. '   <prefs>'
+      .. '     <pref name="fieldType" value="ReferenceMark"/>'
+    -- .. '     <pref name="delayCitationUpdates" value="true"/>'
+      .. '   </prefs>'
+      .. '</data>',
+    csl_style)
+end
+
+local function zotero_bibl_odt_banner()
+  if not (config.format == 'odt' and config.csl_style and config.transferable) then
+    return error('zotero_bibl_odt_banner: This should not happen')
+  end
+
+  local banner = ''
+    .. '<text:p text:style-name="Bibliography_20_1">'
+    .. 'ZOTERO_TRANSFER_DOCUMENT'
+    .. '</text:p>'
+    .. '<text:p text:style-name="Bibliography_20_1">'
+    .. 'The Zotero citations in this document have been converted to a format'
+    .. 'that can be safely transferred between word processors. Open this'
+    .. 'document in a supported word processor and press Refresh in the Zotero'
+    .. 'plugin to continue working with the citations.'
+    .. '</text:p>'
+
+  local doc_preferences = ''
+    .. '<text:p text:style-name="Text_20_body">'
+    .. '<text:a xlink:type="simple" xlink:href="https://www.zotero.org/" text:style-name="Internet_20_link">'
+    .. 'DOCUMENT_PREFERENCES '
+    .. utils.xmlescape(zotero_docpreferences_odt(config.csl_style))
+    .. '</text:a>'
+    .. '</text:p>'
+
+  return banner .. doc_preferences
+end
+
 local function zotero_bibl_odt()
   if config.format ~= 'odt' or not config.csl_style then
     return error('zotero_bibl_odt: This should not happen')
   end
 
   local message = '<Bibliography: Do Zotero Refresh>'
-  local docprefs = '{"uncited":[],"omitted":[],"custom":[]}'
+  local bib_settings = '{"uncited":[],"omitted":[],"custom":[]}'
+
+  if config.transferable then
+    return
+      '<text:p text:style-name="Text_20_body">'
+      .. '<text:a xlink:type="simple" xlink:href="https://www.zotero.org/" text:style-name="Internet_20_link">'
+      .. 'BIBL '
+      .. utils.xmlescape(bib_settings)
+      .. ' '
+      .. 'CSL_BIBLIOGRAPHY'
+      .. '</text:a>'
+      .. '</text:p>'
+
+  end
 
   return string.format(
     '<text:section text:name=" %s">'
@@ -51,7 +105,7 @@ local function zotero_bibl_odt()
       .. utils.xmlescape(message)
       .. '</text:p>'
       ..'</text:section>',
-    'ZOTERO_BIBL ' .. utils.xmlescape(docprefs) .. ' CSL_BIBLIOGRAPHY' .. ' RND' .. utils.random_id(10))
+    'ZOTERO_BIBL ' .. utils.xmlescape(bib_settings) .. ' CSL_BIBLIOGRAPHY' .. ' RND' .. utils.random_id(10))
 end
 
 -- -- -- citation market generators -- -- --
@@ -116,6 +170,15 @@ local function zotero_ref(cite)
 
     return pandoc.RawInline('openxml', field)
   else
+    if config.transferable then
+      local field = ''
+        .. '<text:a xlink:type="simple" xlink:href="https://www.zotero.org/" text:style-name="Internet_20_link">'
+        .. 'ITEM CSL_CITATION '
+        .. utils.xmlescape(json.encode(csl))
+        .. '</text:a>'
+      return pandoc.RawInline('opendocument', field)
+    end
+
     csl = 'ZOTERO_ITEM CSL_CITATION ' .. utils.xmlescape(json.encode(csl)) .. ' RND' .. utils.random_id(10)
     local field = '<text:reference-mark-start text:name="' .. csl .. '"/>'
     field = field .. utils.xmlescape(message)
@@ -221,6 +284,11 @@ function Meta(meta)
     config.csl_style = pandoc.utils.stringify(meta.zotero['csl-style'])
   end
 
+  config.transferable = test_boolean('transferable', meta.zotero['transferable'])
+
+  -- refuse to create a transferable document, when csl style is not specified
+  config.transferable = config.transferable and config.csl_style
+
   if type(meta.zotero.client) == 'nil' then -- should never happen as the default is 'zotero'
     meta.zotero.client = 'zotero'
   else
@@ -252,16 +320,7 @@ function Meta(meta)
 
   if config.format == 'odt' and config.csl_style then
     -- These will be added to the document metadata by pandoc automatically
-    meta.ZOTERO_PREF_1 = string.format(
-      '<data data-version="3" zotero-version="5.0.89">'
-        .. '   <session id="OGe1IYVe"/>'
-        .. '   <style id="http://www.zotero.org/styles/%s" locale="en-US" hasBibliography="1" bibliographyStyleHasBeenSet="0"/>'
-        .. '   <prefs>'
-        .. '     <pref name="fieldType" value="ReferenceMark"/>'
-      -- .. '     <pref name="delayCitationUpdates" value="true"/>'
-        .. '   </prefs>'
-        .. '</data>',
-      config.csl_style)
+    meta.ZOTERO_PREF_1 = zotero_docpreferences_odt(config.csl_style)
     meta.ZOTERO_PREF_2 = ''
   end
 
@@ -291,17 +350,24 @@ end
 
 local refsDivSeen=false
 function Div(div)
-  if refsDivSeen or not div.attr or div.attr.identifier ~= 'refs' then return nil end
-  if config.format ~= 'odt' or not config.csl_style then return nil end
+  if not div.attr or div.attr.identifier ~= 'refs' then return nil end
+  refsDivSeen=true
+  if config.format ~= 'odt' or (not config.csl_style) then return nil end
 
-  refsDivSeen = true
   return pandoc.RawBlock('opendocument', zotero_bibl_odt())
 end
 
 function Doc(doc)
-  if refsDivSeen or config.format ~= 'odt' or not config.csl_style then return nil end
+  if config.format ~= 'odt' then return nil end
 
-  table.insert(doc.blocks, pandoc.RawBlock('opendocument', zotero_bibl_odt()))
+  if config.transferable then
+    table.insert(doc.blocks, 1, pandoc.RawBlock('opendocument', zotero_bibl_odt_banner()))
+  end
+
+  if config.csl_style and not refsDivSeen then
+    table.insert(doc.blocks, pandoc.RawBlock('opendocument', zotero_bibl_odt()))
+  end
+
   return pandoc.Pandoc(doc.blocks, doc.meta)
 end
 


### PR DESCRIPTION
```
commit c6b62dfc8f4a09e8a44ba83cd119934354bc5e10
Author: Jambunathan K <kjambunathan@gmail.com>
Date:   Thu Jul 30 15:36:51 2020 +0530

    zotero.lua: Add support for generating transferable live ODT document
    
    * pandoc/pandoc-zotero-live-citemarkers.lua (config): New field
    `transferable'.
    
    (Meta): Set `config.style' from metadata variable
    `zotero_transferable'.  Update meta.xml, only if the doc is
    non-transferable.
    
    (zotero_docpreferences_odt, zotero_bibl_odt_banner): New
    functions.
    
    (zotero_bibl_odt, zotero_ref): Handle `config.transferable'.
    
    (Doc): Transferable documents require a banner (and document
    preferences) right at the beginning of body text.
    
    * pandoc/Makefile (ZOTERO_TRANSFERABLE): New variable.
    
    (odt-scannable-cite.odt, odt-with-csl-style.odt)
    (odt-without-csl-style.odt): Use above variable.
    
    Add support for generating transferable documents.  See 'Moving
    Documents with Zotero Citations Between Word Processors'
    (https://www.zotero.org/support/kb/moving_documents_between_word_processors).
    
    A document can be transferred only if it has a prior style.
    
    You can generate transferable documents with
    
        pandoc -s --metadata=zotero_csl_style:chicago-author-date \
        --metadata=zotero_transferable:true  -L zotero.lua ...
    
    For discussions surrounging this feature see
    
        https://github.com/retorquere/zotero-better-bibtex/pull/1586
        https://github.com/retorquere/zotero-better-bibtex/pull/1592
```