### PR TITLE
arXiv source

### DIFF
--- a/translators/bibtex/reference.ts
+++ b/translators/bibtex/reference.ts
@@ -430,7 +430,7 @@ export class Reference {
       }
     }
 
-    if ((this.item.libraryCatalog || '').match(/^arxiv(\.org)?$/i) && (this.item.arXiv = arXiv.parse(this.item.publicationTitle)) && this.item.arXiv.id) {
+    if (this.item.publicationTitle && (this.item.arXiv = arXiv.parse(this.item.publicationTitle)) && this.item.arXiv.id) {
       this.item.arXiv.source = 'publicationTitle'
       if (Translator.BetterBibLaTeX) delete this.item.publicationTitle
 


### PR DESCRIPTION
With this, `item.arXiv.source` will only depend on values in Zotero's Publication and Extra fields.