### PR TITLE
Add cite key option to support roam references

### DIFF
--- a/translators/Better BibTeX Citation Key Quick Copy.ts
+++ b/translators/Better BibTeX Citation Key Quick Copy.ts
@@ -52,6 +52,12 @@ const Mode = { // tslint:disable-line:variable-name
     if (Translator.preferences.quickCopyPandocBrackets) keys = `[${keys}]`
     Zotero.write(keys)
   },
+  
+  roamCiteKey(items) {
+    let keys = items.map(item => `[[@${item.citationKey}]]`)
+    keys = keys.join(' ')
+    Zotero.write(keys)
+  },
 
   orgRef(items) {
     if (!items.length) return  ''


### PR DESCRIPTION
First time contributor here. Roam Research is gaining traction in the academic community and some importers already exist which let you create pages using better bib text cite keys ([see here](https://github.com/melat0nin/zotero-roam-export)).

In roam a page is referenced using [[@PAGETITLE]]. I implemented a simple roam cite key option which maps items to their better bib tex keys.

If there is a way to contribute this functionality without hard coding it i.e. through the string-template option I see here then I would be happy to use an alternative.