### PR TITLE
Add citekey pattern using the tex.shortauthor extra field with [auth:lower] fallback to docs

### DIFF
--- a/site/content/citing/_index.md
+++ b/site/content/citing/_index.md
@@ -69,6 +69,14 @@ A common pattern is `[auth:lower][year]`, which means
 If you want to get fancy, you can set multiple patterns separated by a vertical bar, of which the first will be applied
 that yields a non-empty string. If all return a empty string, a random key will be generated.
 
+A handy application for this behavior is to use the `tex.shortauthor` in the [extra field]({{< ref "../exporting/extra-fields" >}}) if defined to generate short citation keys for entries with long group author names, but to default to `[auth:lower]` otherwise:
+
+```text
+[Extra:transliterate:replace=^.*?(?\:tex\\.shortauthor\[\:\=\]\\s+(\\w+))?.*?$,$1,regex:lower][>0][year] | [auth:lower][year]
+```
+
+**note the non-greedy regex pattern before the non-capturing group.** Using this pattern, a reference of the "American Psychological Association" from 2021 and `tex.shortauthor: APA` in the extra field would get the citekey `apa2021`. Without the definition in the extra field the generated citekey would be `americanpsychologicalassociation2021`.
+
 ### Generating citekeys
 
 To generate your citekeys, you use a pattern composed of functions and filters. Broadly, functions grab text from your item, and filters transform that text. The full list of functions and filters is:

--- a/site/content/citing/_index.md
+++ b/site/content/citing/_index.md
@@ -72,7 +72,7 @@ that yields a non-empty string. If all return a empty string, a random key will 
 A handy application for this behavior is to use the `tex.shortauthor` from the [extra field]({{< ref "../exporting/extra-fields" >}}) when defined to generate short citation keys for entries with long group author names, but to default to `[auth:lower]` otherwise:
 
 ```text
-[Extra:transliterate:replace=^.*?(?\:tex\\.shortauthor\[\:\=\]\\s+(\\w+))?.*?$,$1,regex:lower][>0][year] | [auth:lower][year]
+[Extra:transliterate:replace=(?\:tex\\.shortauthor\[\:\=\]\\s+(\\w+))|.*,$1,regex:clean:lower][>0][year] | [auth:lower][year]
 ```
 
 **note the non-greedy regex pattern before the non-capturing group.** Using this pattern, a reference of the "American Psychological Association" from 2021 and `tex.shortauthor: APA` in the extra field would get the citekey `apa2021`. Without the definition in the extra field the generated citekey would be `americanpsychologicalassociation2021`.

--- a/site/content/citing/_index.md
+++ b/site/content/citing/_index.md
@@ -69,7 +69,7 @@ A common pattern is `[auth:lower][year]`, which means
 If you want to get fancy, you can set multiple patterns separated by a vertical bar, of which the first will be applied
 that yields a non-empty string. If all return a empty string, a random key will be generated.
 
-A handy application for this behavior is to use the `tex.shortauthor` in the [extra field]({{< ref "../exporting/extra-fields" >}}) if defined to generate short citation keys for entries with long group author names, but to default to `[auth:lower]` otherwise:
+A handy application for this behavior is to use the `tex.shortauthor` from the [extra field]({{< ref "../exporting/extra-fields" >}}) when defined to generate short citation keys for entries with long group author names, but to default to `[auth:lower]` otherwise:
 
 ```text
 [Extra:transliterate:replace=^.*?(?\:tex\\.shortauthor\[\:\=\]\\s+(\\w+))?.*?$,$1,regex:lower][>0][year] | [auth:lower][year]


### PR DESCRIPTION
As I'm currently using APA 7th edition, I extensively utilize Zotero's "cheater syntax" to define the `tex.shortauthor` in the extra field. After reading #149, I spent some time designing a citekey pattern that uses the `tex.shortauthor` if present and defaults to `[auth:lower]` if not:

```
[Extra:transliterate:replace=(?\:tex\\.shortauthor\[\:\=\]\\s+(\\w+))|.*,$1,regex:clean:lower][>0][year] | [auth:lower][year]
```

I admit, using a regex replace is not very elegant, but it works, and maybe it is useful for others. Hence, the PR to include it in the documentation.

EDIT: Just after this PR, I noticed that when using the previous pattern sometimes $1 referred to the whole input/extra field. This issue is now fixed simplifying the pattern but now requiring a clean after the replace.
