### PR TITLE
Add <tt> -- \texttt{} translation

### DIFF
--- a/translators/bibtex/unicode_translator.ts
+++ b/translators/bibtex/unicode_translator.ts
@@ -157,6 +157,11 @@ const htmlConverter = new class HTMLConverter {
         latex = '\\textbf{...}'
         break
 
+      case 'tt':
+      case 'code':
+        latex = '\\texttt{...}'
+        break
+
       case 'a':
         /* zotero://open-pdf/0_5P2KA4XM/7 is actually a reference. */
         if (tag.attr.href && tag.attr.href.length) latex = `\\href{${tag.attr.href}}{...}`


### PR DESCRIPTION
Can be useful for code names in paper titles