### PR TITLE
Support for org-ref v3

### DIFF
--- a/content/Preferences/export/quickcopy.pug
+++ b/content/Preferences/export/quickcopy.pug
@@ -10,6 +10,7 @@ groupbox
           menuitem(label='&better-bibtex.Preferences.export.quickCopy.pandoc;' value='pandoc')
           menuitem(label='&better-bibtex.Preferences.export.quickCopy.orgMode;' value='orgmode')
           menuitem(label='&better-bibtex.Preferences.export.quickCopy.orgRef;' value='orgRef')
+          menuitem(label='&better-bibtex.Preferences.export.quickCopy.orgRef3;' value='orgRef3')
           menuitem(label='&better-bibtex.Preferences.export.quickCopy.rtfScan;' value='rtfScan')
           menuitem(label='&better-bibtex.Preferences.export.quickCopy.roamCiteKey;' value='roamCiteKey')
           menuitem(label='&better-bibtex.Preferences.export.quickCopy.atom;' value='atom')

--- a/locale/de-DE/zotero-better-bibtex.dtd
+++ b/locale/de-DE/zotero-better-bibtex.dtd
@@ -94,6 +94,7 @@ https://github.com/retorquere/zotero-better-bibtex/issue">
 <!ENTITY better-bibtex.Preferences.export.quickCopy.orgMode.zotero "using Zotero item key">
 <!ENTITY better-bibtex.Preferences.export.quickCopy.orgMode.citekey "using Better BibTeX citation key">
 <!ENTITY better-bibtex.Preferences.export.quickCopy.orgRef "org-ref citation">
+<!ENTITY better-bibtex.Preferences.export.quickCopy.orgRef3 "org-ref v3 citation">
 <!ENTITY better-bibtex.Preferences.export.quickCopy.pandoc.brackets "Surround Pandoc citations with brackets">
 <!ENTITY better-bibtex.Preferences.export.quickCopy.pandoc "Pandoc citation">
 <!ENTITY better-bibtex.Preferences.export.quickCopy.selectLink "Zotero select link">

--- a/locale/en-US/zotero-better-bibtex.dtd
+++ b/locale/en-US/zotero-better-bibtex.dtd
@@ -94,6 +94,7 @@ https://github.com/retorquere/zotero-better-bibtex/issue">
 <!ENTITY better-bibtex.Preferences.export.quickCopy.orgMode.zotero "using Zotero item key">
 <!ENTITY better-bibtex.Preferences.export.quickCopy.orgMode.citekey "using Better BibTeX citation key">
 <!ENTITY better-bibtex.Preferences.export.quickCopy.orgRef "org-ref citation">
+<!ENTITY better-bibtex.Preferences.export.quickCopy.orgRef3 "org-ref v3 citation">
 <!ENTITY better-bibtex.Preferences.export.quickCopy.pandoc.brackets "Surround Pandoc citations with brackets">
 <!ENTITY better-bibtex.Preferences.export.quickCopy.pandoc "Pandoc citation">
 <!ENTITY better-bibtex.Preferences.export.quickCopy.selectLink "Zotero select link">

--- a/locale/fr-FR/zotero-better-bibtex.dtd
+++ b/locale/fr-FR/zotero-better-bibtex.dtd
@@ -94,6 +94,7 @@ https://github.com/retorquere/zotero-better-bibtex/issue">
 <!ENTITY better-bibtex.Preferences.export.quickCopy.orgMode.zotero "en utilisant la clé d'élément de Zotero">
 <!ENTITY better-bibtex.Preferences.export.quickCopy.orgMode.citekey "en utilisant la clé de citation de Better BibTeX">
 <!ENTITY better-bibtex.Preferences.export.quickCopy.orgRef "Citation org-ref">
+<!ENTITY better-bibtex.Preferences.export.quickCopy.orgRef3 "Citation org-ref v3">
 <!ENTITY better-bibtex.Preferences.export.quickCopy.pandoc.brackets "Encadrer les citations 'Pandoc' avec des crochets">
 <!ENTITY better-bibtex.Preferences.export.quickCopy.pandoc "Citation Pandoc">
 <!ENTITY better-bibtex.Preferences.export.quickCopy.selectLink "Lien de sélection de Zotero">

--- a/locale/pt-BR/zotero-better-bibtex.dtd
+++ b/locale/pt-BR/zotero-better-bibtex.dtd
@@ -94,6 +94,7 @@ https://github.com/retorquere/zotero-better-bibtex/issue">
 <!ENTITY better-bibtex.Preferences.export.quickCopy.orgMode.zotero "using Zotero item key">
 <!ENTITY better-bibtex.Preferences.export.quickCopy.orgMode.citekey "using Better BibTeX citation key">
 <!ENTITY better-bibtex.Preferences.export.quickCopy.orgRef "org-ref citation">
+<!ENTITY better-bibtex.Preferences.export.quickCopy.orgRef3 "org-ref v3 citation">
 <!ENTITY better-bibtex.Preferences.export.quickCopy.pandoc.brackets "Surround Pandoc citations with brackets">
 <!ENTITY better-bibtex.Preferences.export.quickCopy.pandoc "Pandoc citation">
 <!ENTITY better-bibtex.Preferences.export.quickCopy.selectLink "Zotero select link">

--- a/site/content/installation/preferences/export.md
+++ b/site/content/installation/preferences/export.md
@@ -104,6 +104,7 @@ Options:
 * Pandoc citation
 * Org-mode select link
 * org-ref citation
+* org-ref v3 citation
 * RTF Scan marker
 * Roam Cite Key
 * Atom (https://atom.io/packages/zotero-citations)

--- a/test/features/steps/bbtjsonschema.json
+++ b/test/features/steps/bbtjsonschema.json
@@ -316,6 +316,7 @@
                 "pandoc",
                 "orgmode",
                 "orgRef",
+                "orgRef3",
                 "rtfScan",
                 "roamCiteKey",
                 "atom",

--- a/test/features/steps/preferences.json
+++ b/test/features/steps/preferences.json
@@ -623,6 +623,7 @@
       "pandoc": "Pandoc citation",
       "orgmode": "Org-mode select link",
       "orgRef": "org-ref citation",
+      "orgRef3": "org-ref v3 citation",
       "rtfScan": "RTF Scan marker",
       "roamCiteKey": "Roam Cite Key",
       "atom": "Atom (https://atom.io/packages/zotero-citations)",

--- a/translators/Better BibTeX Citation Key Quick Copy.ts
+++ b/translators/Better BibTeX Citation Key Quick Copy.ts
@@ -76,6 +76,12 @@ const Mode = {
     Zotero.write(`cite:${items.map(item => item.citationKey).join(', ')}`)
   },
 
+  orgRef3(items) {
+    if (!items.length) return  ''
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    Zotero.write(`cite:&${items.map(item => item.citationKey).join(';&')}`)
+  },
+
   orgmode(items) {
     switch (Translator.preferences.quickCopyOrgMode) {
       case 'zotero':


### PR DESCRIPTION
- New citation export format of the form `cite:&key` and multiple keys of the form `cite:&key1;&key2;&key3`. 
- Added appropriate references wherever I found `orgref` mentioned. 
- Tested locally.


* `translators/Better BibTeX Citation Key Quick Copy.ts`: new logic for org-ref v3