### PR TITLE
Extend RPC interface to list all collections

### DIFF
--- a/content/json-rpc.ts
+++ b/content/json-rpc.ts
@@ -86,6 +86,19 @@ class NSAutoExport {
 
 class NSUser {
   /**
+   * List all collections available in Zotero
+   */
+  public async collections() {
+    /* eslint-disable @typescript-eslint/no-unsafe-return */
+    return Zotero.Libraries.getAll()
+      .map(lib => lib.libraryID)
+      .map(libId => ({
+        ...Zotero.Collections.getByLibrary(libId, true),
+        libraryID: libId,
+      }))
+  }
+
+  /**
    * List the libraries (also known as groups) the user has in Zotero
    */
   public async groups() {

--- a/content/json-rpc.ts
+++ b/content/json-rpc.ts
@@ -86,24 +86,18 @@ class NSAutoExport {
 
 class NSUser {
   /**
-   * List all collections available in Zotero
-   */
-  public async collections() {
-    /* eslint-disable @typescript-eslint/no-unsafe-return */
-    return Zotero.Libraries.getAll()
-      .map(lib => lib.libraryID)
-      .map(libId => ({
-        ...Zotero.Collections.getByLibrary(libId, true),
-        libraryID: libId,
-      }))
-  }
-
-  /**
    * List the libraries (also known as groups) the user has in Zotero
+   *
+   * @param includeCollections Wether or not the result should inlcude a list of collection for each library (default is false)
    */
-  public async groups() {
+  public async groups(includeCollections?: boolean) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    return await Zotero.Libraries.getAll().map(lib => ({ id: lib.libraryID, name: lib.name }))
+    return await Zotero.Libraries
+      .getAll().map(lib => ({
+        id: lib.libraryID,
+        name: lib.name,
+        collections: includeCollections ? Zotero.Collections.getByLibrary(lib.libraryID, true) : undefined,
+      }))
   }
 }
 


### PR DESCRIPTION
Hello,

I'm working on [MonsterWriter](https://www.monsterwriter.app/) and try to integrate the Zotero Desktop version into the app.
This change would be needed, so I could base the integration on better-bibtex.

See related issue https://github.com/retorquere/zotero-better-bibtex/issues/1941.