### PR TITLE
JSON-RPC: Include annotations with attachments

### DIFF
--- a/content/json-rpc.ts
+++ b/content/json-rpc.ts
@@ -166,6 +166,16 @@ class NSItem {
     return (await getItemsAsync(item.getAttachments())).map(att => ({
       open: `zotero://open-pdf/${Zotero.API.getLibraryPrefix(item.libraryID || Zotero.Libraries.userLibraryID)}/items/${att.key}`,
       path: att.getFilePath(),
+      annotations: att.getAnnotations().map(raw => {
+        const annot = raw.toJSON()
+
+        if (annot.annotationPosition && typeof annot.annotationPosition === 'string') {
+          annot.annotationPosition = JSON.parse(annot.annotationPosition)
+        }
+
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        return annot
+      }),
     }))
   }
 


### PR DESCRIPTION
This PR includes Zotero's native PDF annotations with an item's attachments using the `item.attachments` endpoint.

Example output:

```json
{
  "jsonrpc": "2.0",
  "result": [
    {
      "open": "zotero://open-pdf/library/items/K254PIHU",
      "path": "/Users/****/Cockell and Herrera - 2008 - Why are some microorganisms boring.pdf",
      "annotations": [
        {
          "key": "WK35324J",
          "version": 0,
          "itemType": "annotation",
          "parentItem": "K254PIHU",
          "annotationType": "highlight",
          "annotationAuthorName": "",
          "annotationText": "Why are some microorganisms boring?",
          "annotationComment": "",
          "annotationColor": "#80ff80",
          "annotationPageLabel": "101",
          "annotationSortIndex": "00000|000000|00073",
          "annotationPosition": {
            "pageIndex": 0,
            "rects": [[42.52, 694.323, 562.481, 720.014]]
          },
          "tags": [],
          "relations": {},
          "dateAdded": "2022-04-02T18:56:24Z",
          "dateModified": "2022-04-02T18:56:24Z"
        },
        {
          "key": "I5B8T3J8",
          "version": 0,
          "itemType": "annotation",
          "parentItem": "K254PIHU",
          "annotationType": "highlight",
          "annotationAuthorName": "",
          "annotationText": "Some taxa of microorganisms are known to bore holes in rocks and this is an evolutionarily ancient characteristic (Table 1). Bore holes created by phototrophs in stromatolites from the Dahongyu Formation in China date back at least 1500 million years [1], but older borings made into 3.4 billion-year old Archean (see Glossary) volcanic glasses by microorganisms have been reported [2]. Thus the selection pressure for boring activity predates the evolution of animals.",
          "annotationComment": "",
          "annotationColor": "#ffbf80",
          "annotationPageLabel": "101",
          "annotationSortIndex": "00000|000908|00376",
          "annotationPosition": {
            "pageIndex": 0,
            "rects": [
              [42.52, 408.438, 293.548, 417.419],
              [42.52, 396.985, 293.586, 405.967],
              [42.52, 385.533, 293.587, 394.515],
              [42.52, 374.081, 293.577, 383.063],
              [42.52, 362.629, 293.593, 371.611],
              [42.52, 351.177, 293.596, 360.159],
              [42.52, 339.725, 293.568, 348.706],
              [42.52, 328.272, 293.566, 337.254],
              [42.52, 316.82, 79.858, 325.802]
            ]
          },
          "tags": [],
          "relations": {},
          "dateAdded": "2022-04-02T18:56:24Z",
          "dateModified": "2022-04-02T18:56:24Z"
        },
        {
          "key": "L6EVYI9D",
          "version": 0,
          "itemType": "annotation",
          "parentItem": "K254PIHU",
          "annotationType": "note",
          "annotationAuthorName": "",
          "annotationComment": "This is an orange note",
          "annotationColor": "#ffbf80",
          "annotationPageLabel": "101",
          "annotationSortIndex": "00000|002402|00147",
          "annotationPosition": {
            "pageIndex": 0,
            "rects": [[367.844, 624.631, 389.844, 646.631]]
          },
          "tags": [],
          "relations": {},
          "dateAdded": "2022-04-02T18:56:25Z",
          "dateModified": "2022-04-02T18:56:25Z"
        },
        {
          "key": "HZA5DLCH",
          "version": 0,
          "itemType": "annotation",
          "parentItem": "K254PIHU",
          "annotationType": "highlight",
          "annotationAuthorName": "",
          "annotationText": "1–3 mm [14]. The distribution of different types of euendoliths, and thus their boring patterns at different depths, can be used as a",
          "annotationComment": "",
          "annotationColor": "#ec2814",
          "annotationPageLabel": "101",
          "annotationSortIndex": "00000|002626|00228",
          "annotationPosition": {
            "pageIndex": 0,
            "rects": [
              [311.528, 555.538, 562.584, 565.495],
              [311.528, 544.086, 562.566, 554.043],
              [311.528, 532.634, 381.837, 542.591]
            ]
          },
          "tags": [],
          "relations": {},
          "dateAdded": "2022-04-08T00:09:02Z",
          "dateModified": "2022-04-08T00:09:02Z"
        },
        {
          "key": "D99WTXI8",
          "version": 1584,
          "itemType": "annotation",
          "parentItem": "K254PIHU",
          "annotationType": "highlight",
          "annotationAuthorName": "",
          "annotationText": "suggests that a calcium pump might be involved in cyanobacterial euendolithic boring [17]. One could speculate that originally the uptake of calcium as a nutrient from solution by organisms growing near carbonates would have the side-effect of changing the chemical equilibrium at the surface of the m",
          "annotationComment": "",
          "annotationColor": "#ff6666",
          "annotationPageLabel": "102",
          "annotationSortIndex": "00001|001206|00217",
          "annotationPosition": {
            "pageIndex": 1,
            "rects": [
              [318.614, 566.201, 569.621, 576.158],
              [318.614, 554.749, 569.661, 564.706],
              [318.614, 543.24, 569.643, 553.197],
              [318.614, 531.788, 569.655, 541.745],
              [318.614, 520.336, 569.681, 530.293],
              [318.614, 508.884, 387.765, 518.84]
            ]
          },
          "tags": [],
          "relations": {},
          "dateAdded": "2022-04-08T00:09:08Z",
          "dateModified": "2022-04-08T00:09:08Z"
        }
      ]
    }
  ],
  "id": null
}
```