### PR TITLE
Add JSON-RPC endpoint to return item collections

### DIFF
--- a/content/json-rpc.ts
+++ b/content/json-rpc.ts
@@ -170,6 +170,62 @@ class NSItem {
   }
 
   /**
+   * Fetch the collections containing a range of citekeys
+   *
+   * @param citekeys An array of citekeys
+   * @param includeParents Include all parent collections back to the library root
+   */
+  public async collections(citekeys: string[], includeParents?: boolean) {
+    const keys = Zotero.BetterBibTeX.KeyManager.keys.find({ citekey: { $in: citekeys.map(citekey => citekey.replace('@', '')) } })
+    if (!keys.length) throw { code: INVALID_PARAMETERS, message: `zero matches for ${citekeys.join(',')}` }
+
+    const seen = {}
+    const recurseParents = (libraryID: string, key: string) => {
+      if (!seen[key]) {
+        let col = Zotero.Collections.getByLibraryAndKey(libraryID, key)
+
+        if (!col) return false
+
+        col = col.toJSON()
+
+        if (col.parentCollection) {
+          col.parentCollection = recurseParents(libraryID, col.parentCollection)
+        }
+
+        delete col.relations
+        delete col.version
+
+        seen[key] = col
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      return seen[key]
+    }
+
+    const collections = {}
+    for (const key of keys) {
+      const item = await getItemsAsync(key.itemID)
+      collections[key.citekey] = item.getCollections().map(id => {
+        const col = Zotero.Collections.get(id).toJSON()
+
+        delete col.relations
+        delete col.version
+
+        seen[id] = col
+
+        if (includeParents && col.parentCollection) {
+          col.parentCollection = recurseParents(item.libraryID, col.parentCollection)
+        }
+
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        return col
+      })
+    }
+
+    return collections
+  }
+
+  /**
    * Fetch the notes for a range of citekeys
    *
    * @param citekeys An array of citekeys


### PR DESCRIPTION
This PR continues where #2141 left off (cc: @argenos).

Examples:

Input:
```
{
    "jsonrpc": "2.0",
    "method": "item.collections",
    "params": [
        ["eckerbridges2020"]
    ]
}
```

Output:
```
{
  "jsonrpc": "2.0",
  "result": {
    "eckerbridges2020": [
      {
        "key": "X6J3CF6X",
        "name": "Ecker",
        "parentCollection": "32TAEIAY"
      }
    ]
  },
  "id": null
}
```

---

Input (with `includeParents`)
```
{
    "jsonrpc": "2.0",
    "method": "item.collections",
    "params": [
        ["eckerbridges2020"],
        true
    ]
}
```

Output
```
{
  "jsonrpc": "2.0",
  "result": {
    "eckerbridges2020": [
      {
        "key": "X6J3CF6X",
        "name": "Ecker",
        "parentCollection": {
          "key": "32TAEIAY",
          "name": "Research Essay",
          "parentCollection": {
            "key": "JR7798II",
            "name": "Inquiry and Research",
            "parentCollection": {
              "key": "64BYQ89G",
              "name": "BA",
              "parentCollection": {
                "key": "QV77LVKB",
                "name": "Antioch",
                "parentCollection": false
              }
            }
          }
        }
      }
    ]
  },
  "id": null
}
```
