### PR TITLE
Handle case of null displayOptions

### DIFF
--- a/content/translators.ts
+++ b/content/translators.ts
@@ -410,6 +410,9 @@ export const Translators = new class { // eslint-disable-line @typescript-eslint
   }
 
   public displayOptions(translatorID: string, displayOptions: any): any {
+    if (!displayOptions) {
+      return this.byId[translatorID].displayOptions || {}
+    }
     const defaults = this.byId[translatorID].displayOptions || {}
     for (const [k, v] of Object.entries(defaults)) {
       if (typeof displayOptions[k] === 'undefined') displayOptions[k] = v
@@ -419,7 +422,7 @@ export const Translators = new class { // eslint-disable-line @typescript-eslint
 
   public async exportItems(translatorID: string, displayOptions: any, scope: ExportScope, path: string = null): Promise<string> {
     await Zotero.BetterBibTeX.ready
-    this.displayOptions(translatorID, displayOptions)
+    displayOptions = this.displayOptions(translatorID, displayOptions)
 
     const start = Date.now()
 


### PR DESCRIPTION
The latest update introduced an error when using JSON-RPC `item.export`:

Input:
```
{
	"jsonrpc" : "2.0",
	"method" : "item.export",
	"params" : [["magee2021"], "36a3b0b5-bad0-4a04-b79b-441c7cef77db"]
}
```

Output:
```
{
    "jsonrpc": "2.0",
    "error": {
        "code": -32603,
        "message": "TypeError: displayOptions2 is null"
    },
    "id": null
}
```

This PR adds support for the case when `null` is used for `displayOptions` eg:

```
Translators.exportItems(Translators.getTranslatorId(translator), null, { type: 'items', items: await getItemsAsync(found.map(key => key.itemID)) })
```