### PR TITLE
Replace '.' with sep in authorIni

### DIFF
--- a/content/key-manager/formatter.ts
+++ b/content/key-manager/formatter.ts
@@ -616,7 +616,7 @@ class PatternFormatter {
     const firstAuthor = authors.shift()
 
     // eslint-disable-next-line no-magic-numbers
-    let author = [firstAuthor.substring(0, 5)].concat(authors.map(name => name.substring(0, 1)).join('.')).join(sep)
+    let author = [firstAuthor.substring(0, 5)].concat(authors.map(name => name.substring(0, 1)).join(sep)).join(sep)
     if (this.folding) author = this.clean(author, true)
     return this.$text(author)
   }


### PR DESCRIPTION
Using .join('.') instead of .join(sep) leads to all authors except the first one having a '.' after their surname initials. This commit corrects it to use the defined sep parameter.

Solves Issue #2238 

Note: The resulting src is untested.