### PR TITLE
Less strict parsing of patchDates mapping config

### DIFF
--- a/content/ZoteroPane.ts
+++ b/content/ZoteroPane.ts
@@ -142,7 +142,7 @@ export class ZoteroPane {
     const mapping: Record<string, string> = { 'tex.dateadded': 'dateAdded', 'tex.datemodified': 'dateModified' }
     if (Preference.patchDates.trim()) {
       try {
-        for (const assignment of Preference.patchDates.trim().split(/\s,\s/)) {
+        for (const assignment of Preference.patchDates.trim().split(/\s*,\s*/)) {
           const [, k, v ] = assignment.trim().match(/^([-_a-z09]+)\s*=\s*(dateadded|datemodified)$/i)
           mapping [`tex.${k.toLowerCase()}`] = { dateadded: 'dateAdded', datemodified: 'dateModified' }[v.toLowerCase()]
         }


### PR DESCRIPTION
The mapping required individual fields to be separated by not just by a comma, but by comma with whitespace on both sides. As a result, even the example given in the [documentation](https://retorque.re/zotero-better-bibtex/installation/preferences/hidden-preferences/#patchdates)

```
date-added = dateAdded, timestamp=dateModified
```

did not work. This fix changes the regular expression so that whitespace before and after the comma is optional.