### PR TITLE
Ignore libraryID instead of throwing an error when keysope is global

### DIFF
--- a/content/json-rpc.ts
+++ b/content/json-rpc.ts
@@ -345,9 +345,6 @@ class NSItem {
       if (typeof libraryID !== 'number') throw { code: INVALID_PARAMETERS, message: 'keyscope is library, please provide a library ID' }
       query.$and.push({ libraryID: {$eq: libraryID} })
     }
-    else if (Preference.keyScope === 'global') {
-      if (typeof libraryID === 'number') throw { code: INVALID_PARAMETERS, message: 'keyscope is global, do not provide a library ID' }
-    }
 
     const found = Zotero.BetterBibTeX.KeyManager.keys.find(query)
 


### PR DESCRIPTION
@retorquere Is there any harm in removing this check/error? I've added better support for groups libraries in https://github.com/mgmeyers/obsidian-zotero-integration , but I did so by always passing along the library id to the rpc endpoints. This works for users where `keyScope === 'library'` but not `keyScope === 'global'`. It seems to make sense to me to just ignore the library ID when `keyScope` is `global`, but I might be missing something.

Alternatively, is there a way to check a user's `keyScope` setting via cayw/json-rpc? Maybe we could return it along with the output of `user.groups`? That could be another solution to this issue.