### PR TITLE
Fix misleading error when running zotero.lua against old pandoc version

### DIFF
--- a/pandoc/pandoc-zotero-live-citemarkers.lua
+++ b/pandoc/pandoc-zotero-live-citemarkers.lua
@@ -22,15 +22,15 @@
 -- SOFTWARE.
 --
 
-local json = require('lunajson')
-local csl_locator = require('locator')
-local utils = require('utils')
-local zotero = require('zotero')
-
 if lpeg == nil then
   print('upgrade pandoc to version 2.16.2 or later')
   os.exit()
 end
+
+local json = require('lunajson')
+local csl_locator = require('locator')
+local utils = require('utils')
+local zotero = require('zotero')
 
 -- -- global state -- --
 local config = {


### PR DESCRIPTION
Currently, if I run zotero.lua script against old pandoc version (e.g. 2.12) I get the following error message:
```
./zotero.lua:15: attempt to index a nil value (global 'lpeg')
stack traceback:
        ./zotero.lua:15: in function <./zotero.lua:11>
        [C]: in function 'require'
        ./zotero.lua:1727: in main chunk
```
This is misleading. The pandoc version check exists in code, but doesn't seem to work.

This commit fixes the issue. Now I get proper error message when running with old pandoc.

The conversion is still running fine with newer pandoc. Tested on Windows.