### PR TITLE
Fix memory leak in Elements

### DIFF
--- a/content/create-element.ts
+++ b/content/create-element.ts
@@ -6,12 +6,12 @@ export const NAMESPACE = {
 type Handler = (event?: any) => void | Promise<void>
 
 export class Elements {
-  static all: Set<HTMLElement> = new Set
+  static all: Set<WeakRef<HTMLElement>> = new Set
 
   static removeAll(): void {
-    for (const elt of Array.from(this.all)) {
+    for (const eltRef of this.all) {
       try {
-        elt.remove()
+        eltRef.deref()?.remove()
       }
       catch (err) {}
     }
@@ -37,14 +37,13 @@ export class Elements {
         throw new Error(`unexpected attribute ${a}`)
       }
     }
-    Elements.all.add(elt)
+    Elements.all.add(new WeakRef(elt))
 
     return elt
   }
 
   remove(): void {
     for (const elt of Array.from(this.document.getElementsByClassName(this.className))) {
-      Elements.all.delete(elt as HTMLElement)
       elt.remove()
     }
   }


### PR DESCRIPTION
Every time something calls `Elements#create()`, the new element gets added to `Elements.all`. Elements are only removed from that set when `Elements.removeAll()` or `Elements#remove()` is called.

That would be totally fine if the elements created by that method stuck around in the DOM until Zotero shut down / the plugin was disabled, but that's not the case much of the time. For instance, the [`buildItemContextMenu()` and `buildCollectionContextMenu()`  patches](https://github.com/retorquere/zotero-better-bibtex/blob/ec6ae3e169245d76ff18e9004cd7f03f2a9e6a4d/content/ZoteroPane.ts#L81) append 20+ elements to a submenu which is removed and recreated each time the methods are called. Because the old removed elements are still in `Elements.all`, they can never be garbage collected, and neither can their event handlers and other dependencies. That's only a small amount of memory per element in the typical case, but over a long Zotero runtime, thousands of removed elements could be kept alive by `Elements.all`, and the memory usage would really start to add up.

But there's no reason that `Elements` actually *needs* to hold a strong reference to each of the elements that it creates. It's only holding on to them so that it can remove them later. This PR fixes the leak by replacing the strong element references with [`WeakRef`s](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakRef) and dereferencing them in order to remove them in `removeAll()`. Removing elements from `all` in `remove()` is no longer necessary because the weak references will die eventually anyway.