### PR TITLE
Include example of regex syntax

### DIFF
--- a/content/key-manager/formatter.ts
+++ b/content/key-manager/formatter.ts
@@ -1099,7 +1099,9 @@ export class PatternFormatter {
   }
 
   /**
-   * replaces text, case insensitive when passing a string; `.replace('.etal','&etal')` will replace `.EtAl` with `&etal`
+   * replaces text, case insensitive when passing a string; `.replace('.etal','&etal')` will replace `.EtAl` with `&etal`.
+   * A regex should not be surrounded in quotes and must start and end with `/`.
+   * `[^]` can be used for negation, e.g. `replace(/[^;]/g, '')` will remove all characters except semicolons globally in the string.
    * @param find string or regex to match. String matches are case-insensitive
    * @param replace literal text to replace the match with
    */

--- a/content/key-manager/formatter.ts
+++ b/content/key-manager/formatter.ts
@@ -1100,8 +1100,7 @@ export class PatternFormatter {
 
   /**
    * replaces text, case insensitive when passing a string; `.replace('.etal','&etal')` will replace `.EtAl` with `&etal`.
-   * A regex should not be surrounded in quotes and must start and end with `/`.
-   * `[^]` can be used for negation, e.g. `replace(/[^;]/g, '')` will remove all characters except semicolons globally in the string.
+   * Regexes should not be surrounded by quotes and must follow <a href="https://www.simplilearn.com/tutorials/javascript-tutorial/javascript-regex">the Javascript syntax for regexes.</a>   
    * @param find string or regex to match. String matches are case-insensitive
    * @param replace literal text to replace the match with
    */


### PR DESCRIPTION
It took me some time to figure out the exact regex syntax, so I thought it could be worth mentioning in the docs since there are so many different regex implementation in different languages. It also seems like the syntax has changed somewhat and no longer requires the backslashes mentioned in https://github.com/retorquere/zotero-better-bibtex/issues/1933#issuecomment-973360959). 

Maybe there could also be a section somewhere in the docs with more advanced examples? E.g. I use the following to include only one author if there is only one, and if there is more than one I include first and last author:

```js

(
    authorsn(sep=';').replace(/[^;]/g, '').len('>',0)
    ? authorLast.lower.postfix("\_")+auth.lower.postfix("\_")
    : auth.lower.postfix("\_")
)
+year.postfix("\_")
+shorttitle(2).condense('\-').lower()
```