### PR TITLE
Fix item.attachments documentation

### DIFF
--- a/content/json-rpc.ts
+++ b/content/json-rpc.ts
@@ -226,6 +226,7 @@ class NSItem {
    * List attachments for an item with the given citekey
    *
    * @param citekey  The citekey to search for
+   * @param library  The libraryID to search in (optional)
    */
   public async attachments(citekey: string, library?: string | number) {
     const where : Query = { citationKey: citekey.replace(/^@/, '') }


### PR DESCRIPTION
An old script returned an error saying a citekey could not be found, my usage according to the site documentation appeared to be correct https://retorque.re/zotero-better-bibtex/exporting/json-rpc/index.html#itemattachmentscitekey

The documentation is missing the optional secondary parameter.