### PR TITLE
JSON-RPC.attachments: Return epub and snapshot annotations

### DIFF
--- a/content/json-rpc.ts
+++ b/content/json-rpc.ts
@@ -242,8 +242,8 @@ class NSItem {
         path: att.getFilePath(),
       }
 
-      if (att.isPDFAttachment()) {
-        const rawAnnotations = att.getAnnotations()
+      const rawAnnotations = att.getAnnotations()
+      if (rawAnnotations.length) {
         const annotations: Record<string, any>[] = []
 
         for (const raw of rawAnnotations) {


### PR DESCRIPTION
Pretty straightforward, just had to remove the `isPDFAttachment` check.