### PR TITLE
Fix annotation retrieval error potentially caused by pull request 2936

### DIFF
--- a/content/json-rpc.ts
+++ b/content/json-rpc.ts
@@ -242,28 +242,33 @@ class NSItem {
         path: att.getFilePath(),
       }
 
-      const rawAnnotations = att.getAnnotations()
-      if (rawAnnotations.length) {
-        const annotations: Record<string, any>[] = []
+      if (att.isFileAttachment()) {
 
-        for (const raw of rawAnnotations) {
-          const annot = raw.toJSON()
+        const rawAnnotations = att.getAnnotations()
 
-          if (annot.annotationType === 'image') {
-            if (!await Zotero.Annotations.hasCacheImage(raw)) {
-              await Zotero.PDFRenderer.renderAttachmentAnnotations(raw.parentID)
+        if (rawAnnotations.length) {
+          const annotations: Record<string, any>[] = []
+
+          for (const raw of rawAnnotations) {
+            const annot = raw.toJSON()
+
+            if (annot.annotationType === 'image') {
+              if (!await Zotero.Annotations.hasCacheImage(raw)) {
+                await Zotero.PDFRenderer.renderAttachmentAnnotations(raw.parentID)
+              }
+              annot.annotationImagePath = Zotero.Annotations.getCacheImagePath(raw)
             }
-            annot.annotationImagePath = Zotero.Annotations.getCacheImagePath(raw)
+
+            if (annot.annotationPosition && typeof annot.annotationPosition === 'string') {
+              annot.annotationPosition = JSON.parse(annot.annotationPosition)
+            }
+
+            annotations.push(annot)
           }
 
-          if (annot.annotationPosition && typeof annot.annotationPosition === 'string') {
-            annot.annotationPosition = JSON.parse(annot.annotationPosition)
-          }
-
-          annotations.push(annot)
+          data.annotations = annotations
         }
-
-        data.annotations = annotations
+        
       }
 
       output.push(data)


### PR DESCRIPTION
Hello,

I started getting errors with retrieving annotations with Items that have multiple attachments that include a non file attachment e.g. a pubmed abstract

This is the error.

code: -32603
message:  "Error: getAnnotations() can only be called on file attachments"

Zotero 7 appears to stubbornly error out if you call getAnnotations on a non file attachment e.g. pubmed abstract or link, note etc.

I believe the isPDF check removed recently in pull request 2936 may have caused this problem.
https://github.com/retorquere/zotero-better-bibtex/pull/2936/files

I have replaced the isPDFAttachment this time with isFileAttachment to include the new epub and html attachments in Zotero 7.

Another approach is to catch an error in a try catch manner, maybe you think it is better this way.

Please check first my changes not causing any issues, since I did the edits the quick-and-dirty way in the browser via "github.dev" and unable to check

Thank you for great plugin!

Cheers
 