### PR TITLE
resolve regex library warnings

### DIFF
--- a/util/testcase.py
+++ b/util/testcase.py
@@ -80,7 +80,7 @@ g = Github(os.environ['GITHUB_TOKEN'])
 repo = g.get_repo('retorquere/zotero-better-bibtex')
 issue = repo.get_issue(int(args.issue))
 args.title = re.sub(r'^\[[^\]]+\]\s*:', '', issue.title).strip()
-args.title = re.sub(r'^(Bug|Feature|Feature Request)\s*:', '', args.title, re.IGNORECASE).strip()
+args.title = re.sub(r'^(Bug|Feature|Feature Request)\s*:', '', args.title, flags=re.IGNORECASE).strip()
 args.title = re.sub(r'[^-A-Za-z0-9\s]', '', args.title).strip()
 args.title = sanitize_filename(f'{args.title} #{issue.number}'.strip()).replace('`', '').replace('?', '')
 


### PR DESCRIPTION
## PR Summary
This small PR resolves the annoying regex library warnings showing starting Python3.11:
```python
/tmp/zotero-better-bibtex/util/testcase.py:83: DeprecationWarning: 'count' is passed as positional argument
```