### PR TITLE
Fix syntax for links to citing page.

### DIFF
--- a/site/content/preferences/_index.md
+++ b/site/content/preferences/_index.md
@@ -12,7 +12,7 @@ aliases:
 
 default: ` auth.lower + shorttitle(3,3) + year`
 
-Set the pattern used to generate citation keys. The format of the keys is documented [here]({{ ref . "citing" }}).
+Set the pattern used to generate citation keys. The format of the keys is documented [here]({{% ref "citing" %}}).
 Changing this setting *does not* affect existign keys - for this you would need to select the items and refresh the keys.
 
 
@@ -21,7 +21,7 @@ Changing this setting *does not* affect existign keys - for this you would need 
 
 default: `yes`
 
-If you have deviated from the default citation key format pattern by [specifying your own]({{ ref . "citing" }}), you may
+If you have deviated from the default citation key format pattern by [specifying your own]({{% ref "citing" %}}), you may
 wind up with non-ASCII characters in your citation keys. You can prevent that using the `fold` function at the
 appropriate place in your pattern, but checking this checkbox will just apply `fold` to all your keys.
 


### PR DESCRIPTION
Links to citing not generating correctly on https://retorque.re/zotero-better-bibtex/preferences/index.html. I'm not very familiar with whatever SSG you're using (looks like Hugo?), but I looked another page with working links and copied the code from there. If it's not the right code in the PR, at least it will show you where the changes are needed. Thanks for a great plugin!