### PR TITLE
Update citation key label in Chinese localization

### DIFF
--- a/locale/zh-CN/better-bibtex.ftl
+++ b/locale/zh-CN/better-bibtex.ftl
@@ -1,6 +1,6 @@
 better-bibtex = 
     .label = Better BibTeX
--citation-key = 引用
+-citation-key = 引用关键词
 better-bibtex_auto-export_delete = 正在删除自动导出
 better-bibtex_auto-export_delete_confirm = 您确定要删除此项自动导出吗？该操作不可撤销。
 better-bibtex_aux-scan_prompt = 标签名


### PR DESCRIPTION
https://github.com/MuiseDestiny/zotero-citation registers citation column in itemtree. The corresponding zh-CN locale is named '引用'. Let's change to a more suitable zh-CN locale string. (Be consistent with the locale in the settings panel and item info pane)
