### PR TITLE
Update the name field in package.json (BibTex → BibTeX)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "xpi": {
     "id": "better-bibtex@iris-advies.com",
-    "name": "Better BibTex for Zotero",
+    "name": "Better BibTeX for Zotero",
     "iconURL": "chrome://zotero-better-bibtex/content/skin/better-bibtex.svg",
     "optionsURL": "chrome://zotero/content/preferences/preferences.xul#better-bibtex",
     "updateLink": "https://github.com/retorquere/zotero-better-bibtex/releases/download/v{version}/zotero-better-bibtex-{version}.xpi",


### PR DESCRIPTION
This field is used by downstream projects. For example, [Zotero Plugin Marketplace | Zotero Chinese Community](https://zotero-chinese.com/en/plugins/#search=Better+BibTex+for+Zotero). (https://github.com/zotero-chinese/wiki/issues/443#issuecomment-4248071221)

The current [website](https://retorque.re/zotero-better-bibtex/), [README](https://github.com/retorquere/zotero-better-bibtex/blob/e4440af6e9d7b96a46dc8d5383761f81cdd89fe5/README.md?plain=1#L1), and [menus in Zotero](https://github.com/retorquere/zotero-better-bibtex/blob/e4440af6e9d7b96a46dc8d5383761f81cdd89fe5/locale/en-US/better-bibtex.ftl#L2) use _BibTeX_.
It's better to update the `name` in `package.json` from _BibTex_ to _BibTeX_.

(I'm not a fun of aLtErNaTiNg CaPs, though.)


