### PR TITLE
Fix collection path parsing in JSON-RPC API

### DIFF
--- a/content/collection.ts
+++ b/content/collection.ts
@@ -63,10 +63,10 @@ export async function resolve(library: _ZoteroTypes.Library.LibraryLike, path: s
 
 export async function get(path: string, create = false): Promise<any> {
   if (path[0] !== '/') throw new CollectionError(`collection path ${JSON.stringify(path)} is not an absolute path`, 'notfound')
-  const m = path.match(/[/](^.*?)[/](.+)/)
+  const m = path.match(/^\/([^/]*)\/(.+)/)
   if (!m) throw new CollectionError('path is too short', 'notfound')
 
   const library = Library.get({ libraryID: m[1], groupID: m[1], group: m[1] })
-  if (!library) new CollectionError(`Library ${ m[1] } not found`, 'notfound')
-  return await resolve(library, m[2], create)
+  if (!library) throw new CollectionError(`Library ${ m[1] } not found`, 'notfound')
+  return await resolve(library, `/${m[2]}`, create)
 }


### PR DESCRIPTION
## Summary

- **Broken regex** in `get()` (`content/collection.ts:66`) — `/[/](^.*?)[/](.+)/` can never match any input because the `^` anchor asserts start-of-string after `[/]` already consumed a character. This means `autoexport.add` and `collection.scanAUX` fail for every collection path via JSON-RPC.
- **Missing path prefix** — `resolve()` expects an absolute path (starting with `/`), but `get()` passed `m[2]` without the leading slash, causing a second failure even if the regex were correct.
- **Missing `throw`** — `new CollectionError(...)` on line 70 was constructed but never thrown. Invalid library names silently continued with `undefined`, crashing later with a confusing error.

## Fix

```diff
-  const m = path.match(/[/](^.*?)[/](.+)/)
+  const m = path.match(/^\/([^/]*)\/(.+)/)
   ...
-  if (!library) new CollectionError(`Library ${ m[1] } not found`, 'notfound')
-  return await resolve(library, m[2], create)
+  if (!library) throw new CollectionError(`Library ${ m[1] } not found`, 'notfound')
+  return await resolve(library, `/${m[2]}`, create)
```

## Validation

All documented path formats now parse correctly:

| Input | Library | Collection path |
|-------|---------|----------------|
| `//Papers` | *(empty → My Library)* | `/Papers` |
| `//thesis/aux` | *(empty → My Library)* | `/thesis/aux` |
| `/My Library/Papers` | `My Library` | `/Papers` |
| `/GroupName/Sub/Deep` | `GroupName` | `/Sub/Deep` |

Edge cases (`/`, `//`, bare strings, empty) correctly reject with "path is too short".

The UI-based auto-export is unaffected — it bypasses `get()` entirely.

## Test plan

- [ ] Call `autoexport.add` via JSON-RPC with `//CollectionName` path
- [ ] Call `autoexport.add` with `/LibraryName/CollectionName` path
- [ ] Call `collection.scanAUX` with nested paths
- [ ] Verify invalid library names return proper error message
- [ ] Verify UI-based auto-export still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)