### PR TITLE
Add JSDoc type annotations to public functions

### DIFF
--- a/minitests/title-case.js
+++ b/minitests/title-case.js
@@ -1,1 +1,2 @@
+/** @param {string} text - The input text @returns {string} */
 module.exports.titleCase = function(text) { return text }


### PR DESCRIPTION
## 问题背景
在 retorquere/zotero-better-bibtex 项目中，一些公共函数缺少类型注解。这降低了代码的可读性和维护性，并可能增加类型错误的风险。为公共函数添加类型注解有助于提升代码质量，便于开发者理解和维护。

## 修改内容
- 在 `minitests/title-case.js` 文件中，为 `module.exports.titleCase` 函数添加了 JSDoc 类型注解。
  - 指定参数 `text` 的类型为 `string`。
  - 指定返回类型为 `string`。
- 这是一个纯粹的注释添加，不改变函数的外部行为或 API。

## 验证方式
- 运行 minitests 目录下的现有测试（如果存在），确保功能不受影响。
- 使用 JSDoc 工具解析代码，验证类型注解是否正确被识别。
- 由于是注释改动，不会影响运行时性能或行为。