### PR TITLE
feat(json-rpc): add item.regenerate_key

### DIFF
--- a/content/json-rpc.ts
+++ b/content/json-rpc.ts
@@ -462,9 +462,14 @@ export class NSItem {
    * metadata, enrichment landing later — and the key pinned during phase one
    * no longer matches what current metadata would produce.
    *
-   * Returns an old → new mapping per input citekey. The value is `null` if the
-   * citekey could not be resolved to an item, the item lives in a read-only
-   * library, or the recomputed key did not change.
+   * Returns an old → new mapping per input citekey. The value is `null` only
+   * when the input citekey cannot be resolved to an item. Otherwise the value
+   * is the resulting citekey — equal to the input if the recomputed key is
+   * unchanged, or the new citekey if it changed.
+   *
+   * Read-only library handling is deferred to #3430; once that lands, items in
+   * read-only libraries will regenerate through the same path here without
+   * further changes.
    *
    * Counterpart to the read-only `item.citationkey` lookup. Internally calls
    * the same `KeyManager.fill(..., { replace: true })` path the `Regenerate
@@ -488,25 +493,20 @@ export class NSItem {
     if (!resolved.length) return result
 
     const items = await getItemsAsync(resolved.map(r => r.itemID))
-    const editable = items.filter(item =>
-      !item.isFeedItem
-      && item.isRegularItem()
-      && Zotero.Libraries.get(item.libraryID)?.editable
-    )
-    const editableIDs = new Set(editable.map(item => item.id))
+    const eligible = items.filter(item => !item.isFeedItem && item.isRegularItem())
+    const eligibleIDs = new Set(eligible.map(item => item.id))
 
     for (const r of resolved) {
-      if (!editableIDs.has(r.itemID)) result[r.citekey] = null
+      if (!eligibleIDs.has(r.itemID)) result[r.citekey] = r.oldKey
     }
 
-    if (!editable.length) return result
+    if (!eligible.length) return result
 
-    await Zotero.BetterBibTeX.KeyManager.fill(editable.map(item => item.id), { replace: true })
+    await Zotero.BetterBibTeX.KeyManager.fill(eligible.map(item => item.id), { replace: true })
 
     for (const r of resolved) {
-      if (!editableIDs.has(r.itemID)) continue
-      const newKey = Zotero.BetterBibTeX.KeyManager.get(r.itemID)?.citationKey || null
-      result[r.citekey] = (newKey && newKey !== r.oldKey) ? newKey : null
+      if (!eligibleIDs.has(r.itemID)) continue
+      result[r.citekey] = Zotero.BetterBibTeX.KeyManager.get(r.itemID)?.citationKey || r.oldKey
     }
 
     return result

--- a/content/json-rpc.ts
+++ b/content/json-rpc.ts
@@ -467,22 +467,27 @@ export class NSItem {
    * is the resulting citekey — equal to the input if the recomputed key is
    * unchanged, or the new citekey if it changed.
    *
-   * Read-only library handling is deferred to #3430; once that lands, items in
-   * read-only libraries will regenerate through the same path here without
-   * further changes.
+   * Read-only library handling is deferred to #3430; until that lands, scope
+   * the call to a writeable library via `library` to avoid touching read-only
+   * items.
    *
    * Counterpart to the read-only `item.citationkey` lookup. Internally calls
    * the same `KeyManager.fill(..., { replace: true })` path the `Regenerate
    * BibTeX key` right-click menu item invokes.
    *
    * @param citekeys  Array of citekeys whose items should be regenerated.
+   * @param library   The libraryID to search in (optional). Pass `*` to search across your library and all groups.
    */
-  public async regenerate_key(citekeys: string[]): Promise<Record<string, string | null>> {
+  public async regenerate_key(citekeys: string[], library?: string | number): Promise<Record<string, string | null>> {
+    if (typeof library === 'undefined') library = Zotero.Libraries.userLibraryID
+    const libraryID = library === '*' ? undefined : getLibrary(library)
+
     const result: Record<string, string | null> = {}
     const resolved: { citekey: string; itemID: number; oldKey: string }[] = []
 
     for (const citekey of citekeys) {
-      const matched = Zotero.BetterBibTeX.KeyManager.any(byKey(citekey))
+      const matchKey = byKey(citekey)
+      const matched = Zotero.BetterBibTeX.KeyManager.any(_ => (library === '*' || _.libraryID === libraryID) && matchKey(_))
       if (!matched) {
         result[citekey] = null
         continue

--- a/content/json-rpc.ts
+++ b/content/json-rpc.ts
@@ -454,6 +454,65 @@ export class NSItem {
   }
 
   /**
+   * Regenerate citekeys from current item metadata. For each input citekey, the
+   * underlying item's key is recomputed using the configured `citekeyFormat`,
+   * and any `Citation Key:` pin in the Extra field is refreshed to match.
+   *
+   * Useful when items were created in two phases — initial record from partial
+   * metadata, enrichment landing later — and the key pinned during phase one
+   * no longer matches what current metadata would produce.
+   *
+   * Returns an old → new mapping per input citekey. The value is `null` if the
+   * citekey could not be resolved to an item, the item lives in a read-only
+   * library, or the recomputed key did not change.
+   *
+   * Counterpart to the read-only `item.citationkey` lookup. Internally calls
+   * the same `KeyManager.fill(..., { replace: true })` path the `Regenerate
+   * BibTeX key` right-click menu item invokes.
+   *
+   * @param citekeys  Array of citekeys whose items should be regenerated.
+   */
+  public async regenerate_key(citekeys: string[]): Promise<Record<string, string | null>> {
+    const result: Record<string, string | null> = {}
+    const resolved: { citekey: string; itemID: number; oldKey: string }[] = []
+
+    for (const citekey of citekeys) {
+      const matched = Zotero.BetterBibTeX.KeyManager.any(byKey(citekey))
+      if (!matched) {
+        result[citekey] = null
+        continue
+      }
+      resolved.push({ citekey, itemID: matched.itemID, oldKey: matched.citationKey })
+    }
+
+    if (!resolved.length) return result
+
+    const items = await getItemsAsync(resolved.map(r => r.itemID))
+    const editable = items.filter(item =>
+      !item.isFeedItem
+      && item.isRegularItem()
+      && Zotero.Libraries.get(item.libraryID)?.editable
+    )
+    const editableIDs = new Set(editable.map(item => item.id))
+
+    for (const r of resolved) {
+      if (!editableIDs.has(r.itemID)) result[r.citekey] = null
+    }
+
+    if (!editable.length) return result
+
+    await Zotero.BetterBibTeX.KeyManager.fill(editable.map(item => item.id), { replace: true })
+
+    for (const r of resolved) {
+      if (!editableIDs.has(r.itemID)) continue
+      const newKey = Zotero.BetterBibTeX.KeyManager.get(r.itemID)?.citationKey || null
+      result[r.citekey] = (newKey && newKey !== r.oldKey) ? newKey : null
+    }
+
+    return result
+  }
+
+  /**
    * Generate an export for a list of citekeys
    *
    * @param citekeys      Array of citekeys

--- a/test/features/json-rpc.feature
+++ b/test/features/json-rpc.feature
@@ -16,3 +16,10 @@ Feature: JSON-RPC API
     And I call JSON-RPC method "item.regenerate_key" with params [["Smith2024"]]
     Then the JSON-RPC response should have no error
     And the JSON-RPC result for "Smith2024" should be "Smith2024"
+
+  @item_regenerate_key
+  Scenario: item.regenerate_key accepts a library selector
+    When I import 1 reference from "json-rpc/regenerate-key.json"
+    And I call JSON-RPC method "item.regenerate_key" with params [["Smith2024"], "*"]
+    Then the JSON-RPC response should have no error
+    And the JSON-RPC result for "Smith2024" should be "Smith2024"

--- a/test/features/json-rpc.feature
+++ b/test/features/json-rpc.feature
@@ -1,0 +1,11 @@
+@json-rpc
+Feature: JSON-RPC API
+
+  Background:
+    Given I set the temp directory to "test/tmp"
+
+  @item_regenerate_key
+  Scenario: item.regenerate_key is reachable and returns null for an unresolvable citekey
+    When I call JSON-RPC method "item.regenerate_key" with params [["does-not-exist-12345"]]
+    Then the JSON-RPC response should have no error
+    And the JSON-RPC result for "does-not-exist-12345" should be null

--- a/test/features/json-rpc.feature
+++ b/test/features/json-rpc.feature
@@ -9,3 +9,10 @@ Feature: JSON-RPC API
     When I call JSON-RPC method "item.regenerate_key" with params [["does-not-exist-12345"]]
     Then the JSON-RPC response should have no error
     And the JSON-RPC result for "does-not-exist-12345" should be null
+
+  @item_regenerate_key
+  Scenario: item.regenerate_key echoes the input citekey when the recomputed key is unchanged
+    When I import 1 reference from "json-rpc/regenerate-key.json"
+    And I call JSON-RPC method "item.regenerate_key" with params [["Smith2024"]]
+    Then the JSON-RPC response should have no error
+    And the JSON-RPC result for "Smith2024" should be "Smith2024"

--- a/test/features/steps/steps.py
+++ b/test/features/steps/steps.py
@@ -555,3 +555,8 @@ def step_impl(context):
 def step_impl(context, citekey):
   result = context.jsonrpc_response.get('result', {})
   assert result.get(citekey) is None, f'Expected null for {citekey}; got {result.get(citekey)!r}'
+
+@then(u'the JSON-RPC result for "{citekey}" should be "{expected}"')
+def step_impl(context, citekey, expected):
+  result = context.jsonrpc_response.get('result', {})
+  assert result.get(citekey) == expected, f'Expected {expected!r} for {citekey}; got {result.get(citekey)!r}'

--- a/test/features/steps/steps.py
+++ b/test/features/steps/steps.py
@@ -20,6 +20,7 @@ import html, re
 import timeit
 import platform
 import pytablewriter
+import requests
 
 from contextlib import contextmanager
 
@@ -536,3 +537,21 @@ def step_impl(context, nth, name):
   ''', nth=nth, itemID=context.selected[0], name=name)
 
 
+
+@when(u'I call JSON-RPC method "{method}" with params {params}')
+def step_impl(context, method, params):
+  response = requests.post(
+    'http://127.0.0.1:23119/better-bibtex/json-rpc',
+    json={'jsonrpc': '2.0', 'method': method, 'params': json.loads(params), 'id': 1},
+    headers={'Content-Type': 'application/json'},
+  )
+  context.jsonrpc_response = response.json()
+
+@then(u'the JSON-RPC response should have no error')
+def step_impl(context):
+  assert 'error' not in context.jsonrpc_response, f'Unexpected error: {context.jsonrpc_response.get("error")}'
+
+@then(u'the JSON-RPC result for "{citekey}" should be null')
+def step_impl(context, citekey):
+  result = context.jsonrpc_response.get('result', {})
+  assert result.get(citekey) is None, f'Expected null for {citekey}; got {result.get(citekey)!r}'

--- a/test/fixtures/json-rpc/regenerate-key.json
+++ b/test/fixtures/json-rpc/regenerate-key.json
@@ -1,0 +1,29 @@
+{
+  "config": {
+    "id": "36a3b0b5-bad0-4a04-b79b-441c7cef77db",
+    "label": "BetterBibTeX JSON",
+    "localeDateOrder": "ymd",
+    "options": {
+      "exportNotes": true
+    },
+    "preferences": {
+      "citekeyFormat": "auth + year"
+    }
+  },
+  "items": [
+    {
+      "itemID": 1,
+      "itemType": "journalArticle",
+      "title": "Test reference for item.regenerate_key json-rpc method",
+      "citationKey": "Smith2024",
+      "creators": [
+        {
+          "creatorType": "author",
+          "firstName": "John",
+          "lastName": "Smith"
+        }
+      ],
+      "date": "2024"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #3529.

Adds `item.regenerate_key(citekeys: string[]) → Record<string, string | null>` to the json-rpc surface. For each input citekey, the underlying item's key is recomputed using the configured `citekeyFormat` and any `Citation Key:` pin in Extra is refreshed to match. The implementation calls `KeyManager.fill(..., { replace: true })` — the same path the `Regenerate BibTeX key` right-click menu item invokes (see `content/better-bibtex.ts` line 638).

### Result shape

| Condition | Returned value for that input |
|---|---|
| Input citekey could not be resolved to an item | `null` |
| Otherwise | citekey string — input value if the recomputed key is unchanged, new value if it changed |

`null` is reserved for the single "could not resolve" case so the response is deterministic — every other input returns a string.

Read-only library handling deferred to #3430. Once that lands, items in read-only libraries will regenerate through the same path here without further changes.

### Test scaffolding

No existing json-rpc method in the suite has a Behave test, so this PR introduces a minimal scaffold:

- 3 generic step impls in `test/features/steps/steps.py` (call JSON-RPC method, assert no error, assert null result) reusable for any future json-rpc test
- 1 scenario in `test/features/json-rpc.feature` exercising the unresolvable-citekey case (confirms the method is registered and the documented response shape works)

Steps use `requests.post` directly against `http://127.0.0.1:23119/better-bibtex/json-rpc` so the full HTTP dispatch path is covered, rather than going via `TestSupport`.

A happy-path scenario (stale pin → recomputed key) would need a deterministic `citekeyFormat` plus a fixture item — happy to add if useful.