### PR TITLE
fix getNote error in cayw

### DIFF
--- a/content/cayw.ts
+++ b/content/cayw.ts
@@ -143,7 +143,7 @@ async function selected(options: CAYWOptions): Promise<string> {
     uri: Zotero.URI.getItemURI(item),
     itemType: typeof item.itemType === 'string' ? item.itemType : undefined,
     title: item.getField('title'),
-    note: typeof item.note === 'string' ? item.note : undefined,
+    note: item.isNote() ? item.note : undefined,
   }))
   if (!formatter.acceptsNotes) picked = itemPicks(picked)
   return picked.length ? await formatter(picked, options) : ''


### PR DESCRIPTION
`item.note` throws error in Zotero 9.0.5:

```
Better BibTeX: CAYW Failed C: Users\ ... \codebase\readwise-scripts> Error: getNote() can only be called on notes and attachments (1/GX9THS2B is a book)
```