### PR TITLE
Sort the JabRef groups field with the collator used for keywords

### DIFF
--- a/test/fixtures/export/Better BibTeX does not export collections #901.bibtex
+++ b/test/fixtures/export/Better BibTeX does not export collections #901.bibtex
@@ -404,7 +404,7 @@ assur\'ee par les services de traduction de l'Universit\'e McGill.},
   abstract = {Daniel Dennett's book, Darwin's Dangerous Idea, offers a naturalistic teleology and a theory of the intentionality of the mental. Both are grounded in a neo-Darwinian account of evolutionary adaptation. I argue that Dennett's empirical assumptions about the evolution of psychological phenotypes may well be unwarranted; and that, in any event, the intentionality of minds is quite different from and not reducible to the intensionality of selection.},
   langid = {english},
   keywords = {Darwin,Dennett D,Epistemology,Intentionality,Knowledge,Naturalism},
-  groups = {Intentionnalité naturalisation,_Non-classees},
+  groups = {_Non-classees,Intentionnalité naturalisation},
   timestamp = {2015-02-24 12:14:36 +0100}
 }
 % == BibTeX quality report for Fodor-1996-DeconstructingDennettsDarwin:
@@ -529,7 +529,7 @@ assur\'ee par les services de traduction de l'Universit\'e McGill.},
   issn = {0279-0750},
   langid = {english},
   keywords = {Etiology,Functionalism,Science,Wright L},
-  groups = {Références mémoire (créé le 16 oct. 2006),_Non-classees},
+  groups = {_Non-classees,Références mémoire (créé le 16 oct. 2006)},
   timestamp = {2015-02-24 12:14:36 +0100}
 }
 

--- a/translators/bibtex/entry.ts
+++ b/translators/bibtex/entry.ts
@@ -745,7 +745,7 @@ export class Entry {
 
   public complete(): void {
     if (this.translation.collected.preferences.jabrefFormat >= 4 && this.item.collections?.length) {
-      const groups = Array.from(new Set(this.item.collections.map(key => this.translation.collections[key]?.name).filter(name => name))).sort()
+      const groups = Array.from(new Set(this.item.collections.map(key => this.translation.collections[key]?.name).filter(name => name))).sort((a, b) => strcmp.base(a, b))
       this.add({ name: 'groups', value: groups.join(',') })
     }
 


### PR DESCRIPTION
`Entry.complete()` builds the JabRef `groups` field by collecting the item's collection names and sorting them with a bare `Array.prototype.sort()`, which orders by UTF-16 code unit:

```js
const groups = Array.from(new Set(this.item.collections.map(key => this.translation.collections[key]?.name).filter(name => name))).sort()
this.add({ name: 'groups', value: groups.join(',') })
```

The `keywords` field is built the same way (sort a set of strings, then join with commas), but it sorts with `strcmp.base` from `content/string-compare`:

```js
return [...encoded].sort((a, b) => strcmp.base(a, b)).join(',')
```

This makes `groups` use the same collator so the two comma-joined fields order consistently. Names that begin with punctuation or contain accented characters now sort the way the collator orders them rather than by raw code unit; plain ASCII names are unaffected.

The one fixture with multi-value `groups` (`Better BibTeX does not export collections #901`) updates accordingly: `_Non-classees` now sorts ahead of the letter-initial names, the same way `_tablet` already sorts first in the existing `keywords` fixtures.
