### PR TITLE
Fix: honor skipFields in Better Hayagriva export

### DIFF
--- a/translators/lib/hayagriva.ts
+++ b/translators/lib/hayagriva.ts
@@ -412,11 +412,20 @@ export const Hayagriva = new class {
     return entry
   }
 
-  public export(items: Iterable<Serialized.RegularItem>): string {
+  public export(items: Iterable<Serialized.RegularItem>, translation?: Translation): string {
     const doc: Doc = {}
     for (const item of items) {
       const key = sanitizeKey(item.citationKey || item.itemKey)
-      doc[key] = this.fromZotero(item)
+      const entry = this.fromZotero(item)
+
+      if (translation?.skipField) {
+        for (const field of Object.keys(entry)) {
+          // Hayagriva is a non-TeX exporter, so skipField matches on `csl.<type>.<field>` (see Translation.typefield)
+          if (`csl.${ entry.type }.${ field }`.match(translation.skipField)) delete entry[field as keyof Entry]
+        }
+      }
+
+      doc[key] = entry
     }
 
     return YAML.dump(doc, { skipInvalid: true, sortKeys: true, lineWidth: -1 })
@@ -535,6 +544,6 @@ export const Hayagriva = new class {
 
 export function generateHayagriva(collected: Collected): Translation {
   const translation = Translation.Export(collected)
-  translation.output.body = Hayagriva.export(collected.items.regular)
+  translation.output.body = Hayagriva.export(collected.items.regular, translation)
   return translation
 }


### PR DESCRIPTION
### Problem
`skipFields` is declared to affect **Better Hayagriva**, and `Translation` builds the `skipField` matcher for it, but the Hayagriva exporter never consulted it. The BibTeX and CSL exporters already apply it.

### Fix
Apply `skipField` in `Hayagriva.export()`: after building each entry, drop any field whose `csl.<type>.<field>` name matches, mirroring the CSL exporter. Since Hayagriva is a non-TeX exporter, a bare name (`url`) skips across all types and a qualified `article.url` skips it per type.

### Test
`npm run build` passed. Exporting with e.g. `skipFields = url` now omits the field from Hayagriva output.